### PR TITLE
Mainly cleared up some sections with methods that allowed for better …

### DIFF
--- a/src/main/java/io/github/toberocat/core/commands/FactionCommand.java
+++ b/src/main/java/io/github/toberocat/core/commands/FactionCommand.java
@@ -17,43 +17,39 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabExecutor;
 import org.bukkit.entity.Player;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 public class FactionCommand implements TabExecutor {
 
-    public static List<SubCommand> subCommands = new ArrayList<>();
+    public static HashSet<SubCommand> subCommands = new HashSet<>();
 
     public FactionCommand() {
-        subCommands.add(new ConfigSubCommand());
-        subCommands.add(new PluginSubCommand());
-        subCommands.add(new CreateFactionSubCommand());
-        subCommands.add(new DeleteFactionSubCommand());
-        subCommands.add(new ZoneSubCommand());
-        subCommands.add(new HelpSubCommand());
-        subCommands.add(new AdminSubCommand());
-        subCommands.add(new SettingsSubCommand());
-        subCommands.add(new ClaimSubCommand());
-        subCommands.add(new RelationSubCommand());
-        subCommands.add(new ExtensionSubCommand());
-        subCommands.add(new LeaveFactionSubCommand());
-        subCommands.add(new WhoSubCommand());
-        subCommands.add(new BanSubCommand());
-        subCommands.add(new UnBanSubCommand());
-        subCommands.add(new KickSubCommand());
-        subCommands.add(new OnlineSubCommand());
-        subCommands.add(new JoinFactionSubCommand());
-        subCommands.add(new MembersSubCommand());
+        subCommands.addAll(Set.of(
+                new ConfigSubCommand(),
+                new PluginSubCommand(),
+                new CreateFactionSubCommand(),
+                new DeleteFactionSubCommand(),
+                new ZoneSubCommand(),
+                new HelpSubCommand(),
+                new AdminSubCommand(),
+                new SettingsSubCommand(),
+                new ClaimSubCommand(),
+                new RelationSubCommand(),
+                new ExtensionSubCommand(),
+                new LeaveFactionSubCommand(),
+                new WhoSubCommand(),
+                new BanSubCommand(),
+                new UnBanSubCommand(),
+                new KickSubCommand(),
+                new OnlineSubCommand(),
+                new JoinFactionSubCommand(),
+                new MembersSubCommand()));
     }
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         //Player is null if commandblock or console
-        Player player = null;
-
-        if (sender instanceof Player) {
-            player = (Player) sender;
-        }
+        Player player = sender instanceof Player ? (Player) sender : null;
 
         if (args.length == 0 && player != null) {
             HelpSubCommand.Help(player);
@@ -70,12 +66,10 @@ public class FactionCommand implements TabExecutor {
 
     @Override
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
-        Player player = null;
-        if (sender instanceof Player) {
-            player = (Player) sender;
-        }
+        //Player is null if commandblock or console
+        Player player = sender instanceof Player ? (Player) sender : null;
 
-        List<String> arguments = SubCommand.CallSubCommandsTab(FactionCommand.subCommands, player, args);
+        Set<String> arguments = SubCommand.CallSubCommandsTab(FactionCommand.subCommands, player, args);
 
         if (arguments == null) return null;
 

--- a/src/main/java/io/github/toberocat/core/commands/admin/AdminHardResetSubCommand.java
+++ b/src/main/java/io/github/toberocat/core/commands/admin/AdminHardResetSubCommand.java
@@ -41,7 +41,7 @@ public class AdminHardResetSubCommand extends SubCommand {
             PlayerSettings.getLoadedSettings().clear();
 
             MainIF.getIF().getSaveEvents().clear();
-            MainIF.LogMessage(Level.SEVERE, "&cImprovedFactions got a reset. Please reload / restart the server");
+            MainIF.logMessage(Level.SEVERE, "&cImprovedFactions got a reset. Please reload / restart the server");
             Language.sendMessage(LangMessage.COMMAND_ADMIN_HARD_RESET_SUCCESS, player);
             MainIF.getIF().getPluginLoader().disablePlugin(MainIF.getIF());
         }

--- a/src/main/java/io/github/toberocat/core/commands/admin/AdminSubCommand.java
+++ b/src/main/java/io/github/toberocat/core/commands/admin/AdminSubCommand.java
@@ -5,19 +5,24 @@ import io.github.toberocat.core.utility.command.SubCommand;
 import io.github.toberocat.core.utility.language.LangMessage;
 import org.bukkit.entity.Player;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
-public class AdminSubCommand extends SubCommand  {
+public class AdminSubCommand extends SubCommand {
     public AdminSubCommand() {
         super("admin", LangMessage.COMMAND_ADMIN_DESCRIPTION, true);
-        subCommands.add(new AdminHardResetSubCommand());
-        subCommands.add(new AdminDisbandSubCommand());
-        subCommands.add(new AdminGetPlayerFactionSubCommand());
-        subCommands.add(new AdminIsPlayerInFactionSubCommand());
-        subCommands.add(new AdminRegenerateSubCommand());
-        subCommands.add(new AdminPermanentSubCommand());
-        subCommands.add(new AdminFreezeSubCommand());
-        subCommands.add(new JoinPrivateFactionSubCommand());
+        subCommands.addAll(
+                Set.of(new AdminHardResetSubCommand(),
+                        new AdminDisbandSubCommand(),
+                        new AdminGetPlayerFactionSubCommand(),
+                        new AdminIsPlayerInFactionSubCommand(),
+                        new AdminRegenerateSubCommand(),
+                        new AdminPermanentSubCommand(),
+                        new AdminFreezeSubCommand(),
+                        new JoinFactionSubCommand(),
+                        new JoinPrivateFactionSubCommand()));
+
     }
 
     @Override

--- a/src/main/java/io/github/toberocat/core/commands/config/ConfigSaveSubCommand.java
+++ b/src/main/java/io/github/toberocat/core/commands/config/ConfigSaveSubCommand.java
@@ -17,7 +17,7 @@ public class ConfigSaveSubCommand extends SubCommand {
 
     @Override
     protected void CommandExecute(Player player, String[] args) {
-        List<String> savedConfigs = MainIF.getIF().SaveConfigs();
+        List<String> savedConfigs = MainIF.getIF().saveConfigs();
         List<String> differences = new ArrayList<>(MainIF.getIF().getDataManagers().keySet());
         differences.removeAll(savedConfigs);
 

--- a/src/main/java/io/github/toberocat/core/commands/config/ConfigSubCommand.java
+++ b/src/main/java/io/github/toberocat/core/commands/config/ConfigSubCommand.java
@@ -5,16 +5,18 @@ import io.github.toberocat.core.utility.language.LangMessage;
 import org.bukkit.entity.Player;
 
 import java.util.List;
+import java.util.Set;
 
 public class ConfigSubCommand extends SubCommand {
 
     public ConfigSubCommand() {
         super("config", LangMessage.COMMAND_CONFIG_DESCRIPTION, true);
-        subCommands.add(new ConfigBackupSubCommand());
-        subCommands.add(new ConfigSaveSubCommand());
-        subCommands.add(new ConfigReloadSubCommand());
-        subCommands.add(new ConfigRemoveAllBackupSubCommand());
-        subCommands.add(new ConfigConfigureSubCommand());
+        subCommands.addAll(Set.of(
+                new ConfigBackupSubCommand(),
+                new ConfigSaveSubCommand(),
+                new ConfigReloadSubCommand(),
+                new ConfigRemoveAllBackupSubCommand(),
+                new ConfigConfigureSubCommand()));
     }
 
     @Override

--- a/src/main/java/io/github/toberocat/core/commands/factions/claim/ClaimSubCommand.java
+++ b/src/main/java/io/github/toberocat/core/commands/factions/claim/ClaimSubCommand.java
@@ -22,7 +22,8 @@ public class ClaimSubCommand extends SubCommand {
     @Override
     protected void CommandExecute(Player player, String[] args) {
         if (args.length == 0) {
-            subCommands.get(0).CallSubCommand(player, new String[]{});
+            List<SubCommand> convertedSubCommands = subCommands.stream().toList();
+            convertedSubCommands.get(0).CallSubCommand(player, new String[]{});
         }
     }
 

--- a/src/main/java/io/github/toberocat/core/commands/factions/unclaim/UnclaimSubCommand.java
+++ b/src/main/java/io/github/toberocat/core/commands/factions/unclaim/UnclaimSubCommand.java
@@ -22,7 +22,8 @@ public class UnclaimSubCommand extends SubCommand {
     @Override
     protected void CommandExecute(Player player, String[] args) {
         if (args.length == 0) {
-            subCommands.get(0).CallSubCommand(player, new String[]{});
+            List<SubCommand> convertedSubCommands = subCommands.stream().toList();
+            convertedSubCommands.get(0).CallSubCommand(player, new String[]{});
         }
     }
 

--- a/src/main/java/io/github/toberocat/core/commands/plugin/PluginDisableSubCommand.java
+++ b/src/main/java/io/github/toberocat/core/commands/plugin/PluginDisableSubCommand.java
@@ -25,7 +25,7 @@ public class PluginDisableSubCommand extends SubCommand {
         if (player != null) {
             Language.sendMessage(LangMessage.COMMAND_PLUGIN_DISABLE_SUCCESS, player);
         } else {
-            MainIF.LogMessage(Level.INFO, Language.getMessage(LangMessage.COMMAND_PLUGIN_DISABLE_SUCCESS, "en_us"));
+            MainIF.logMessage(Level.INFO, Language.getMessage(LangMessage.COMMAND_PLUGIN_DISABLE_SUCCESS, "en_us"));
         }
         MainIF.getIF().getPluginLoader().disablePlugin(MainIF.getIF());
     }

--- a/src/main/java/io/github/toberocat/core/commands/plugin/PluginStandbySubCommand.java
+++ b/src/main/java/io/github/toberocat/core/commands/plugin/PluginStandbySubCommand.java
@@ -16,7 +16,7 @@ public class PluginStandbySubCommand extends SubCommand  {
     @Override
     protected void CommandExecute(Player player, String[] args) {
         Language.sendMessage(LangMessage.COMMAND_PLUGIN_STANDBY_SUCCESS, player);
-        MainIF.getIF().SaveShutdown("&cUser " + player.getName() + " requested standby. Everything was working correctly");
+        MainIF.getIF().saveShutdown("&cUser " + player.getName() + " requested standby. Everything was working correctly");
     }
 
     @Override

--- a/src/main/java/io/github/toberocat/core/debug/Debugger.java
+++ b/src/main/java/io/github/toberocat/core/debug/Debugger.java
@@ -11,20 +11,20 @@ public class Debugger {
     public static void log(String message) {
         AsyncCore.Run(() -> {
             if (MainIF.getConfigManager().getValue("general.debugMode"))
-                MainIF.LogMessage(Level.INFO, "&7"+message);
+                MainIF.logMessage(Level.INFO, "&7"+message);
         });
     }
 
     public static void logWarning(String message) {
         AsyncCore.Run(() -> {
             if (MainIF.getConfigManager().getValue("general.debugMode"))
-                MainIF.LogMessage(Level.WARNING, "&7"+message);
+                MainIF.logMessage(Level.WARNING, "&7"+message);
         });
     }
 
     public static boolean hasPermission(Player player, String perm) {
         AsyncCore.Run(() -> {
-            if (MainIF.getConfigManager().getValue("general.debugMode")) MainIF.LogMessage(Level.INFO,
+            if (MainIF.getConfigManager().getValue("general.debugMode")) MainIF.logMessage(Level.INFO,
                     "Permission check for &6" + player.getName() + "&7 with &6" + perm);
         });
 

--- a/src/main/java/io/github/toberocat/core/extensions/Extension.java
+++ b/src/main/java/io/github/toberocat/core/extensions/Extension.java
@@ -28,7 +28,7 @@ public abstract class Extension {
         ExtensionListLoader.getExtensionVersion(filename).setFinishCallback((newestVersion) -> {
             UpdateChecker checker = new UpdateChecker(registry.version(), newestVersion);
             if (!checker.isNewestVersion()) {
-                MainIF.LogMessage(Level.INFO, "&aHey! There is a newer version of "
+                MainIF.logMessage(Level.INFO, "&aHey! There is a newer version of "
                         + registry.displayName() + ". Use &7/f extension update&a to get the newest version");
             }
         });
@@ -36,10 +36,10 @@ public abstract class Extension {
         if (canEnable(plugin)) {
             OnEnable(plugin);
             if (Arrays.asList(registry.testedVersions()).contains(MainIF.getVersion()))
-                MainIF.LogMessage(Level.INFO, "&aLoading &6" + registry.displayName() + "&a with tested " +
+                MainIF.logMessage(Level.INFO, "&aLoading &6" + registry.displayName() + "&a with tested " +
                         "version &6" + MainIF.getVersion());
             else
-                MainIF.LogMessage(Level.INFO, "&aLoading &6" + registry.displayName() + "&a with version " +
+                MainIF.logMessage(Level.INFO, "&aLoading &6" + registry.displayName() + "&a with version " +
                         "&6" + MainIF.getVersion() + "&a. &eThere may be problems with this extension");
             enabled = true;
         }
@@ -49,14 +49,14 @@ public abstract class Extension {
         if (registry.dependencies() != null) {
             for (String depend : registry.dependencies()) {
                 if (plugin.getServer().getPluginManager().getPlugin(depend) == null) {
-                    MainIF.LogMessage(Level.WARNING, "&cDidn't find " + depend + ". "
+                    MainIF.logMessage(Level.WARNING, "&cDidn't find " + depend + ". "
                             + registry.displayName() + " requires " + Arrays.toString(registry.dependencies()));
                     return false;
                 }
             }
         }
         if (registry.minVersion().versionToInteger() < MainIF.getVersion().versionToInteger()) {
-            MainIF.LogMessage(Level.WARNING, "§c &6" + registry.displayName() + "v" + registry.version() + "&a " +
+            MainIF.logMessage(Level.WARNING, "§c &6" + registry.displayName() + "v" + registry.version() + "&a " +
                     "needs a minimum version of &6" + registry.minVersion() + "&a. Currently on &6" + MainIF.getVersion());
             return false;
         }

--- a/src/main/java/io/github/toberocat/core/utility/Utility.java
+++ b/src/main/java/io/github/toberocat/core/utility/Utility.java
@@ -36,7 +36,7 @@ public class Utility {
      */
     public static <T> ObjectPair<T, T[]> shift(T[] list) {
         List<T> t = Arrays.asList(list);
-        MainIF.LogMessage(Level.INFO, ""+list.length);
+        MainIF.logMessage(Level.INFO, ""+list.length);
         T tShift = t.remove(0);
         return new ObjectPair<>(tShift, toArray(t));
     }
@@ -113,7 +113,7 @@ public class Utility {
      * @param lore The lore the item should have
      * @return the old item tags with modified meta
      */
-    public static ItemStack modiflyItem(ItemStack stack, String title, String... lore) {
+    public static ItemStack modifyItem(ItemStack stack, String title, String... lore) {
         ItemMeta meta = stack.getItemMeta();
         meta.setDisplayName(Language.format(title));
         SetLore(lore, meta);
@@ -137,7 +137,7 @@ public class Utility {
 
     public static void except(Exception e) {
         if (MainIF.getConfigManager().getValue("general.printStacktrace")) e.printStackTrace();
-        MainIF.getIF().SaveShutdown(e.getMessage());
+        MainIF.getIF().saveShutdown(e.getMessage());
     }
 
     public static String[] getNames(Class<? extends Enum<?>> e) {

--- a/src/main/java/io/github/toberocat/core/utility/command/SubCommand.java
+++ b/src/main/java/io/github/toberocat/core/utility/command/SubCommand.java
@@ -16,7 +16,7 @@ import java.util.*;
 
 public abstract class SubCommand {
 
-    protected final ArrayList<SubCommand> subCommands;
+    protected final HashSet<SubCommand> subCommands;
 
     private static SubCommand lastSubCommand;
 
@@ -36,7 +36,7 @@ public abstract class SubCommand {
         this.permission = permission;
         this.description = descriptionKey;
         this.manager = manager;
-        subCommands = new ArrayList<>();
+        subCommands = new HashSet<>();
 
         if (getSettings().isAllowAliases()) {
             MainIF.getConfigManager().getDataManager("commands.yml").getConfig().addDefault("commands." + permission + ".aliases", new ArrayList<String>());
@@ -51,7 +51,7 @@ public abstract class SubCommand {
         this.permission = subCommand;
         this.description = descriptionKey;
         this.manager = manager;
-        subCommands = new ArrayList<>();
+        subCommands = new HashSet<>();
 
         if (getSettings().isAllowAliases()) {
             MainIF.getConfigManager().AddToDefaultConfig("commands." + permission + ".aliases", new ArrayList<String>(),"commands.yml");
@@ -67,8 +67,8 @@ public abstract class SubCommand {
         return "usage";
     }
 
-    public static List<String> CallSubCommandsTab(List<SubCommand> subCommands, Player player, String[] args) {
-        List<String> arguments = new ArrayList<>();
+    public static HashSet<String> CallSubCommandsTab(HashSet<SubCommand> subCommands, Player player, String[] args) {
+        HashSet<String> arguments = new HashSet<>();
         if (args.length == 1) { //Means: The first subcommand is determined
             for (SubCommand command : subCommands) {
                 String[] newArguments = Arrays.copyOfRange(args, 1, args.length);
@@ -86,7 +86,7 @@ public abstract class SubCommand {
                         if (str == null) {
                             str = new ArrayList<>();
                         }
-                        List<String> subCommandStr = SubCommand.CallSubCommandsTab(command.subCommands, player, newArguments);
+                        HashSet<String> subCommandStr = SubCommand.CallSubCommandsTab(command.subCommands, player, newArguments);
                         if (subCommandStr != null) {
                             str.addAll(subCommandStr);
                         }
@@ -126,7 +126,7 @@ public abstract class SubCommand {
         return new SubCommandSettings();
     }
 
-    public static AsyncCore<Boolean> CallSubCommands(String commandPath, List<SubCommand> subCommands, Player player, String[] args) {
+    public static AsyncCore<Boolean> CallSubCommands(String commandPath, Set<SubCommand> subCommands, Player player, String[] args) {
         return AsyncCore.Run(() -> {
             if (args.length == 0) return false;
             for (SubCommand command : subCommands) {
@@ -250,7 +250,7 @@ public abstract class SubCommand {
 
         while(subs.hasNext()) {
             SubCommand cmd = subs.next();
-            if (cmd.getSubCommand() == command) {
+            if (cmd.getSubCommand().equals(command)) {
                 subs.remove();
                 return true;
             }
@@ -259,7 +259,7 @@ public abstract class SubCommand {
         return false;
     }
 
-    public ArrayList<SubCommand> getSubCommands() {
+    public HashSet<SubCommand> getSubCommands() {
         return subCommands;
     }
 

--- a/src/main/java/io/github/toberocat/core/utility/command/SubCommandSettings.java
+++ b/src/main/java/io/github/toberocat/core/utility/command/SubCommandSettings.java
@@ -116,7 +116,7 @@ public class SubCommandSettings {
 
     public boolean canDisplay(SubCommand subCommand, Player player, String[] args, boolean messages) {
         if (player == null && !canUseInConsole) {
-            if (messages) MainIF.LogMessage(Level.INFO, "&cYou can't use this command in the console");
+            if (messages) MainIF.logMessage(Level.INFO, "&cYou can't use this command in the console");
             return false;
         }
 
@@ -139,7 +139,7 @@ public class SubCommandSettings {
 
     public boolean canExecute(SubCommand subCommand, Player player, String[] args, boolean messages) {
         if (player == null && !canUseInConsole) {
-            if (messages) MainIF.LogMessage(Level.INFO, "&cYou can't use this command in the console");
+            if (messages) MainIF.logMessage(Level.INFO, "&cYou can't use this command in the console");
             return false;
         }
         if (argLength != -1 && args.length != argLength) {

--- a/src/main/java/io/github/toberocat/core/utility/config/DataManager.java
+++ b/src/main/java/io/github/toberocat/core/utility/config/DataManager.java
@@ -34,7 +34,7 @@ public class DataManager {
             }
             lore.add("&8Click to configure");
 
-            this.itemIcon = Utility.modiflyItem(itemIcon, itemIcon.getItemMeta().getDisplayName(), lore.toArray(String[]::new));
+            this.itemIcon = Utility.modifyItem(itemIcon, itemIcon.getItemMeta().getDisplayName(), lore.toArray(String[]::new));
         } else {
             this.itemIcon = Utility.createItem(Material.GRASS_BLOCK, "&e&l" + fileName);
         }

--- a/src/main/java/io/github/toberocat/core/utility/data/DataAccess.java
+++ b/src/main/java/io/github/toberocat/core/utility/data/DataAccess.java
@@ -29,13 +29,13 @@ public class DataAccess {
             try {
                 sql.connect();
             } catch (SQLException | ClassNotFoundException e) {
-                MainIF.getIF().SaveShutdown("&cDatabase not connected. Please check if your login information are right");
+                MainIF.getIF().saveShutdown("&cDatabase not connected. Please check if your login information are right");
                 return false;
             }
 
             if (!sql.isConnected()) return false;
 
-            MainIF.LogMessage(Level.INFO, "&aSuccessfully &fconnected to database");
+            MainIF.logMessage(Level.INFO, "&aSuccessfully &fconnected to database");
         }
 
         makeFolder("Factions");

--- a/src/main/java/io/github/toberocat/core/utility/factions/FactionUtility.java
+++ b/src/main/java/io/github/toberocat/core/utility/factions/FactionUtility.java
@@ -27,7 +27,7 @@ public class FactionUtility extends PlayerJoinLoader {
 
     @Override
     protected void loadPlayer(Player player) {
-        MainIF.LogMessage(Level.INFO, "Loading player");
+        MainIF.logMessage(Level.INFO, "Loading player");
         String registry = getPlayerFactionRegistry(player);
         if (registry == null) return; // Player not in faction
         if (Faction.getLoadedFactions().containsKey(registry)) return; // Faction already loaded
@@ -119,7 +119,7 @@ public class FactionUtility extends PlayerJoinLoader {
         faction.getPowerManager().setFaction(faction);
         faction.getRelationManager().setFaction(faction);
 
-        MainIF.LogMessage(Level.INFO, "Loaded &e" + faction.getRegistryName());
+        MainIF.logMessage(Level.INFO, "Loaded &e" + faction.getRegistryName());
         Faction.getLoadedFactions().put(registry, faction);
         return faction;
     }

--- a/src/main/java/io/github/toberocat/core/utility/language/Language.java
+++ b/src/main/java/io/github/toberocat/core/utility/language/Language.java
@@ -34,7 +34,7 @@ public class Language extends PlayerJoinLoader {
     public static boolean init(MainIF plugin, File datatDir) {
         File langDir = new File(datatDir.getPath() + "/lang");
         if (!langDir.exists() && !langDir.mkdir()) {
-            MainIF.getIF().SaveShutdown("Couldn't create folder &6" + langDir.getPath());
+            MainIF.getIF().saveShutdown("Couldn't create folder &6" + langDir.getPath());
             return false;
         }
 
@@ -65,14 +65,14 @@ public class Language extends PlayerJoinLoader {
 
                     for (String key : keysOnlyInSource) {
                         langMessage.getMessages().put(key, defaultMessages.getMessages().get(key));
-                        MainIF.LogMessage(Level.INFO, "&cAdded &6" + key + "&c from default to &6" + file.getName() + "&c, &cbecause it was missing");
+                        MainIF.logMessage(Level.INFO, "&cAdded &6" + key + "&c from default to &6" + file.getName() + "&c, &cbecause it was missing");
                     }
 
                     ObjectMapper saveMapper = new ObjectMapper();
                     saveMapper.writerWithDefaultPrettyPrinter().writeValue(file, langMessage);
                 } catch (IOException e) {
                     if (MainIF.getConfigManager().getValue("general.printStacktrace")) e.printStackTrace();
-                    MainIF.getIF().SaveShutdown("&cCouldn't read language file " + file.getName() + ". Error: &6" + e.getMessage());
+                    MainIF.getIF().saveShutdown("&cCouldn't read language file " + file.getName() + ". Error: &6" + e.getMessage());
                     return false;
                 }
             }
@@ -94,7 +94,7 @@ public class Language extends PlayerJoinLoader {
                 saveMapper.writerWithDefaultPrettyPrinter().writeValue(file, langMessage);
                 LOADED_LANGUAGES.put(split[0], new ObjectPair<>(1, langMessage));
             } catch (IOException e) {
-                MainIF.getIF().SaveShutdown("&cCouldn't read language file " + file.getName() + ". Error: &6" + e.getMessage());
+                MainIF.getIF().saveShutdown("&cCouldn't read language file " + file.getName() + ". Error: &6" + e.getMessage());
             }
         }
     }
@@ -144,7 +144,7 @@ public class Language extends PlayerJoinLoader {
         } else if (LOADED_LANGUAGES.containsKey("en_us")){
             langMessage = LOADED_LANGUAGES.get("en_us").getE();
         } else {
-            MainIF.getIF().SaveShutdown("Wasn't able to find &6en_us&c translation file");
+            MainIF.getIF().saveShutdown("Wasn't able to find &6en_us&c translation file");
             return "";
         }
 

--- a/src/main/java/io/github/toberocat/versions/nms/NMSInterface.java
+++ b/src/main/java/io/github/toberocat/versions/nms/NMSInterface.java
@@ -13,7 +13,7 @@ public interface NMSInterface {
      * This will send a message by default, telling the user what version he currently is using of this plugin
      */
     default void EnableInterface() {
-        MainIF.LogMessage(Level.INFO, "&aDetected version &6" + Bukkit.getBukkitVersion() +
+        MainIF.logMessage(Level.INFO, "&aDetected version &6" + Bukkit.getBukkitVersion() +
                 "&a running on server. Loaded IF version support &6" + getVersion());
     }
 


### PR DESCRIPTION
…readability and less repetition in code.

For example, instead of registering listener by listener with the
`Bukkit.getPluginManager().registerEvents(new blah blah blah)`,
I took advantage of using the Arrays utility class to take advantage of the `.asList()` method along with a forEach for simpler registering of listeners. Used this method as well for registering SubCommands.

Changed the naming of some of the more commonly used methods so that they can follow java naming conventions.

A long with other changes, mainly introduced to improve the quality and readability of the code.

Fixed a common issue that involved using the == operator instead of the .equals() method when comparing strings.