### PR TITLE
fixed mismatch between config options and actual config file

### DIFF
--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/config/PluginConfig.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/config/PluginConfig.kt
@@ -10,8 +10,8 @@ abstract class PluginConfig {
     abstract fun reload(plugin: ImprovedFactionsPlugin, config: FileConfiguration)
 
     protected fun FileConfiguration.generateAllowedWorlds() = computeAllowedWorlds(
-        getStringList("whitelisted").toSet(),
-        getStringList("blacklisted").toSet()
+        getStringList("whitelisted-worlds").toSet(),
+        getStringList("blacklisted-worlds").toSet()
     )
 
     protected fun computeAllowedWorlds(whitelist: Set<String>, blacklist: Set<String>) = when (whitelist.isEmpty()) {


### PR DESCRIPTION
This pull request includes changes to the `PluginConfig` class in the `improved-factions` project to improve configuration handling for allowed worlds.

Configuration improvements:

* [`improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/config/PluginConfig.kt`](diffhunk://#diff-f3f54fefe686f6eff762de970bc17b7e8470d117d167087c6b40db8d449d74cdL13-R14): Updated `generateAllowedWorlds` method to use `whitelisted-worlds` and `blacklisted-worlds` instead of `whitelisted` and `blacklisted` for better clarity and consistency in configuration naming.