### PR TITLE
Mysql Database Connection FIX

### DIFF
--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/claims/clustering/cluster/FactionClusters.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/claims/clustering/cluster/FactionClusters.kt
@@ -6,5 +6,6 @@ import java.util.*
 
 object FactionClusters : IntIdTable("faction_clusters") {
     val faction = reference("faction", Factions)
-    val parentClusterId = uuid("parent_cluster").default(UUID.randomUUID())
+    // val parentClusterId = uuid("parent_cluster").default(UUID.randomUUID()) // <-- This is previous version
+    val parentClusterId = uuid("parent_cluster").clientDefault { UUID.randomUUID() } // <-- Mysql Fix
 }


### PR DESCRIPTION
Mysql database cant alter table for faction claims because uuid in mysql is binary 16... so quickfix for this improvment can be done with this fix... litesql and mysql are both working.