### PR TITLE
Fix #335: Format %faction_next_power_gain% to 2 decimals

### DIFF
--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/power/PowerRaidsModule.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/power/PowerRaidsModule.kt
@@ -84,7 +84,7 @@ object PowerRaidsModule : Module {
         placeholders: HashMap<String, (player: OfflinePlayer) -> String?>
     ) {
         placeholders["next_power_gain"] =
-            { player -> player.factionUser().faction()?.let { handle.getPowerAccumulated(it).toString() } }
+            { player -> player.factionUser().faction()?.let { String.format("%.2f", handle.getPowerAccumulated(it)) } }
         placeholders["active_accumulation"] =
             { player -> player.factionUser().faction()?.let { handle.getActivePowerAccumulation(it).toString() } }
         placeholders["inactive_accumulation"] =

--- a/improved-factions/version.properties
+++ b/improved-factions/version.properties
@@ -1,3 +1,3 @@
-#Mon Sep 15 03:41:19 KST 2025
-buildIncrement=6
+#Sat Dec 27 18:39:05 CET 2025
+buildIncrement=37
 versionName=2.3.1


### PR DESCRIPTION
Formats the %faction_next_power_gain% placeholder to always show two decimal numbers instead of a billion of them.