### PR TITLE
Update ImprovedFactions for Paper 1.21.11

### DIFF
--- a/improved-factions/build.gradle.kts
+++ b/improved-factions/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.google.devtools.ksp.gradle.KspTask
 import java.nio.file.Files
 import java.util.*
 
@@ -6,7 +5,7 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.devtools.ksp)
     id("maven-publish")
-    id("com.gradleup.shadow") version "9.0.0-beta13"
+    id("com.gradleup.shadow") version "9.6.1"
     id("com.github.ben-manes.versions") version "0.52.0"
     id("org.jetbrains.dokka") version "2.1.0"
 }
@@ -18,26 +17,20 @@ if (versionPropsFile.exists()) {
     versionProps.load(versionPropsFile.inputStream())
 }
 
-val buildIncrement = (versionProps["buildIncrement"]?.toString()?.toInt() ?: 1) + 1
+val buildIncrement = versionProps["buildIncrement"]?.toString()?.toInt() ?: 1
 val versionName = versionProps["versionName"]!!.toString()
-
-versionProps["buildIncrement"] = buildIncrement.toString()
-versionProps["versionName"] = versionName
-
-versionProps.store(versionPropsFile.outputStream(), null)
 
 
 group = "io.github.toberocat.improved-factions"
 version = versionName
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 }
 
 repositories {
     mavenCentral()
-    maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
     maven("https://jitpack.io")
     maven("https://repo.extendedclip.com/content/repositories/placeholderapi/")
     maven("https://maven.paulem.net/releases/")
@@ -49,8 +42,8 @@ repositories {
 dependencies {
     implementation(project(":shared"))
 
-    // Spigot API
-    compileOnly(libs.spigot.api)
+    // Paper API
+    compileOnly(libs.paper.api)
 
     // Exposed ORM
     implementation(libs.exposed.core)
@@ -73,7 +66,6 @@ dependencies {
     compileOnly(libs.guiengine)
     implementation(libs.adventure.text.minimessage)
     implementation(libs.adventure.text.serializer.legacy)
-    implementation(libs.kyori.adventure.platform.bukkit)
     implementation(libs.bstats.bukkit)
 
     // Provided dependencies
@@ -99,7 +91,7 @@ tasks.named<Copy>("processResources") {
     }
 }
 
-tasks.withType<KspTask>().configureEach {
+tasks.matching { it.name.startsWith("ksp") }.configureEach {
     dependsOn(generateBuildConfig)
 }
 
@@ -115,9 +107,6 @@ dokka {
 
 tasks.shadowJar {
     archiveFileName.set("${project.name}-${project.version}.jar")
-    if (System.getenv("CI") == null && System.getenv("JITPACK") == null) {
-        destinationDirectory.set(file("../server/plugins"))
-    }
     relocate("com.fasterxml.jackson", "io.github.toberocat.relocated.jackson")
     relocate("net.kyori", "io.github.toberocat.relocated.kyori")
     relocate("dev.s7a", "io.github.toberocat.relocated.base64itemstack")
@@ -131,6 +120,10 @@ tasks.shadowJar {
 }
 
 tasks {
+    jar {
+        enabled = false
+    }
+
     build {
         dependsOn(shadowJar)
     }
@@ -151,7 +144,7 @@ tasks {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 
     sourceSets.main {
         kotlin.srcDir("build/generated/ksp/main/kotlin")

--- a/improved-factions/build.gradle.kts
+++ b/improved-factions/build.gradle.kts
@@ -1,5 +1,6 @@
 import java.nio.file.Files
 import java.util.*
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
@@ -25,8 +26,8 @@ group = "io.github.toberocat.improved-factions"
 version = versionName
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_25
-    targetCompatibility = JavaVersion.VERSION_25
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 repositories {
@@ -145,6 +146,7 @@ tasks {
 
 kotlin {
     jvmToolchain(25)
+    compilerOptions.jvmTarget.set(JvmTarget.JVM_21)
 
     sourceSets.main {
         kotlin.srcDir("build/generated/ksp/main/kotlin")

--- a/improved-factions/code-generation/build.gradle.kts
+++ b/improved-factions/code-generation/build.gradle.kts
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-    implementation("com.google.devtools.ksp:symbol-processing-api:2.0.21-1.0.25")
+    implementation("com.google.devtools.ksp:symbol-processing-api:2.3.9")
     implementation(project(":shared"))
 }

--- a/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/permission/generator/PermissionDocumentationGenerator.kt
+++ b/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/permission/generator/PermissionDocumentationGenerator.kt
@@ -2,13 +2,13 @@ package io.github.toberocat.improvedfactions.permission.generator
 
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.KSPLogger
-import io.github.toberocat.improvedfactions.annotations.permission.Permission
 import io.github.toberocat.improvedfactions.utils.writeDocumentation
+import io.github.toberocat.improvedfactions.permission.visitor.PermissionData
 
 class PermissionDocumentationGenerator(
     private val logger: KSPLogger,
     private val codeGenerator: CodeGenerator,
-    private val permissions: List<Permission>
+    private val permissions: List<PermissionData>
 ) {
 
     fun createPermissionsMd() {
@@ -25,7 +25,7 @@ class PermissionDocumentationGenerator(
         logger.info("Generated permissions.md successfully.")
     }
 
-    private fun buildMarkdown(permissions: List<Permission>): String {
+    private fun buildMarkdown(permissions: List<PermissionData>): String {
         val markdown = StringBuilder()
         markdown.appendLine("# Permissions")
         markdown.appendLine()

--- a/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/permission/generator/PermissionPluginYmlGenerator.kt
+++ b/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/permission/generator/PermissionPluginYmlGenerator.kt
@@ -1,13 +1,13 @@
 package io.github.toberocat.improvedfactions.permission.generator
 
 import com.google.devtools.ksp.processing.KSPLogger
-import io.github.toberocat.improvedfactions.annotations.permission.Permission
+import io.github.toberocat.improvedfactions.permission.visitor.PermissionData
 import java.io.File
 import java.nio.file.Files
 
 class PermissionPluginYmlGenerator(
     private val logger: KSPLogger,
-    private val permissions: List<Permission>
+    private val permissions: List<PermissionData>
 ) {
 
     fun appendYmlToPluginYml(pluginYmlFile: File) {
@@ -45,7 +45,7 @@ class PermissionPluginYmlGenerator(
         }
     }
 
-    private fun buildYaml(permissions: List<Permission>): String {
+    private fun buildYaml(permissions: List<PermissionData>): String {
         val root = PermissionNode("permissions")
 
         for (permission in permissions) {

--- a/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/permission/processor/PermissionProcessor.kt
+++ b/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/permission/processor/PermissionProcessor.kt
@@ -7,6 +7,7 @@ import io.github.toberocat.improvedfactions.annotations.permission.PermissionCon
 import io.github.toberocat.improvedfactions.permission.generator.PermissionDocumentationGenerator
 import io.github.toberocat.improvedfactions.permission.generator.PermissionPluginYmlGenerator
 import io.github.toberocat.improvedfactions.permission.visitor.PermissionVisitor
+import io.github.toberocat.improvedfactions.permission.visitor.PermissionData
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -17,7 +18,7 @@ class PermissionProcessor(
     private val logger: KSPLogger,
     private val pluginYmlFile: File
 ) : SymbolProcessor {
-    private val permissions = mutableListOf<Permission>()
+    private val permissions = mutableListOf<PermissionData>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
         val symbols = resolver.getSymbolsWithAnnotation(Permission::class.qualifiedName!!)
@@ -34,10 +35,8 @@ class PermissionProcessor(
     }
 
     override fun finish() {
-        PermissionPluginYmlGenerator(logger, permissions).appendYmlToPluginYml(pluginYmlFile)
-
         // Add factions.* permission for documentation generation
-        permissions.add(Permission("factions.*", PermissionConfigurations.OP_ONLY))
+        permissions.add(PermissionData("factions.*", PermissionConfigurations.OP_ONLY))
         PermissionDocumentationGenerator(logger, codeGenerator, permissions).createPermissionsMd()
     }
 }

--- a/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/permission/visitor/PermissionVisitor.kt
+++ b/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/permission/visitor/PermissionVisitor.kt
@@ -3,13 +3,19 @@ package io.github.toberocat.improvedfactions.permission.visitor
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSVisitorVoid
 import io.github.toberocat.improvedfactions.annotations.permission.Permission
+import io.github.toberocat.improvedfactions.annotations.permission.PermissionConfigurations
 import io.github.toberocat.improvedfactions.utils.findAnnotation
 
 class PermissionVisitor : KSVisitorVoid() {
-    val permissions = mutableListOf<Permission>()
+    val permissions = mutableListOf<PermissionData>()
 
     override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: Unit) {
         val permissionAnnotation = function.findAnnotation<Permission>() ?: return
-        permissions.add(permissionAnnotation)
+        permissions.add(PermissionData(permissionAnnotation.value, permissionAnnotation.config))
     }
 }
+
+data class PermissionData(
+    val value: String,
+    val config: PermissionConfigurations,
+)

--- a/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/placeholder/generator/PlaceholderDocumentationGenerator.kt
+++ b/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/placeholder/generator/PlaceholderDocumentationGenerator.kt
@@ -1,12 +1,12 @@
 package io.github.toberocat.improvedfactions.placeholder.generator
 
 import com.google.devtools.ksp.processing.CodeGenerator
-import io.github.toberocat.improvedfactions.annotations.papi.PapiPlaceholder
+import io.github.toberocat.improvedfactions.placeholder.visitor.PlaceholderData
 import io.github.toberocat.improvedfactions.utils.writeDocumentation
 
 class PlaceholderDocumentationGenerator(
     private val codeGenerator: CodeGenerator,
-    private val placeholders: MutableList<PapiPlaceholder>
+    private val placeholders: MutableList<PlaceholderData>
 ) {
     fun createPlaceholdersMd() {
         codeGenerator.writeDocumentation(

--- a/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/placeholder/processor/PlaceholderProcessor.kt
+++ b/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/placeholder/processor/PlaceholderProcessor.kt
@@ -7,6 +7,7 @@ import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.KSAnnotated
 import io.github.toberocat.improvedfactions.annotations.papi.PapiPlaceholder
 import io.github.toberocat.improvedfactions.placeholder.generator.PlaceholderDocumentationGenerator
+import io.github.toberocat.improvedfactions.placeholder.visitor.PlaceholderData
 import io.github.toberocat.improvedfactions.placeholder.visitor.PlaceholderVisitor
 
 class PlaceholderProcessor(
@@ -14,7 +15,7 @@ class PlaceholderProcessor(
     private val logger: KSPLogger,
 ) : SymbolProcessor {
 
-    private val placeholders = mutableListOf<PapiPlaceholder>()
+    private val placeholders = mutableListOf<PlaceholderData>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
         val symbols = resolver.getSymbolsWithAnnotation(PapiPlaceholder::class.qualifiedName!!)

--- a/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/placeholder/visitor/PlaceholderVisitor.kt
+++ b/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/placeholder/visitor/PlaceholderVisitor.kt
@@ -6,10 +6,18 @@ import io.github.toberocat.improvedfactions.annotations.papi.PapiPlaceholder
 import io.github.toberocat.improvedfactions.utils.findAnnotations
 
 class PlaceholderVisitor : KSVisitorVoid() {
-    val placeholders = mutableListOf<PapiPlaceholder>()
+    val placeholders = mutableListOf<PlaceholderData>()
 
     override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: Unit) {
         val annotation = function.findAnnotations<PapiPlaceholder>() ?: return
-        placeholders.addAll(annotation)
+        placeholders.addAll(annotation.map {
+            PlaceholderData(it.value, it.module, it.description)
+        })
     }
 }
+
+data class PlaceholderData(
+    val value: String,
+    val module: String,
+    val description: String,
+)

--- a/improved-factions/gradle/libs.versions.toml
+++ b/improved-factions/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin-version = "2.3.20"
 ksp-version = "2.3.9"
-paper-version = "26.2.build.+"
+paper-version = "1.21.11-R0.1-SNAPSHOT"
 exposed-version = "0.61.0"
 jackson-version = "2.19.0"
 kotlinx-datetime-version = "0.6.2"

--- a/improved-factions/gradle/libs.versions.toml
+++ b/improved-factions/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-kotlin-version = "2.0.21"
-ksp-version = "2.0.21-1.0.25"
-spigot-version = "1.18.1-R0.1-SNAPSHOT"
+kotlin-version = "2.3.20"
+ksp-version = "2.3.9"
+paper-version = "26.2.build.+"
 exposed-version = "0.61.0"
 jackson-version = "2.19.0"
 kotlinx-datetime-version = "0.6.2"
@@ -12,7 +12,6 @@ spigot-update-checker-version = "3.0.4"
 guiengine-version = "6c00296e4c"
 adventure-text-minimessages-version = "4.24.0"
 adventure-text-serializer-legacy-version = "4.24.0"
-kyori-adventure-platform-bukkit-version = "4.4.1"
 bstats-bukkit-version = "3.1.0"
 placeholder-api-version = "2.11.6"
 dynmap-api-version = "3.7-beta-6"
@@ -27,7 +26,7 @@ kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit5", versio
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin-version" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-version" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit-jupiter-params-version" }
-spigot-api = { module = "org.spigotmc:spigot-api", version.ref = "spigot-version" }
+paper-api = { module = "io.papermc.paper:paper-api", version.ref = "paper-version" }
 exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed-version" }
 exposed-jdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed-version" }
 exposed-dao = { module = "org.jetbrains.exposed:exposed-dao", version.ref = "exposed-version" }
@@ -43,7 +42,6 @@ spigot-update-checker = { module = "com.jeff_media:SpigotUpdateChecker", version
 guiengine = { module = "com.github.ToberoCat:GuiEngine", version.ref = "guiengine-version" }
 adventure-text-minimessage = { module = "net.kyori:adventure-text-minimessage", version.ref = "adventure-text-minimessages-version" }
 adventure-text-serializer-legacy = { module = "net.kyori:adventure-text-serializer-legacy", version.ref = "adventure-text-serializer-legacy-version" }
-kyori-adventure-platform-bukkit = { module = "net.kyori:adventure-platform-bukkit", version.ref = "kyori-adventure-platform-bukkit-version" }
 bstats-bukkit = { module = "org.bstats:bstats-bukkit", version.ref = "bstats-bukkit-version" }
 placeholderapi = { module = "me.clip:placeholderapi", version.ref = "placeholder-api-version" }
 dynmap-api = { module = "us.dynmap:DynmapCoreAPI", version.ref = "dynmap-api-version" }

--- a/improved-factions/gradle/wrapper/gradle-wrapper.properties
+++ b/improved-factions/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Sep 08 15:07:49 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/improved-factions/settings.gradle.kts
+++ b/improved-factions/settings.gradle.kts
@@ -9,6 +9,5 @@ plugins {
 }
 
 rootProject.name = "ImprovedFactions"
-include("improved-factions")
 include("shared")
 include("code-generation")

--- a/improved-factions/shared/build.gradle.kts
+++ b/improved-factions/shared/build.gradle.kts
@@ -13,5 +13,5 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(25)
 }

--- a/improved-factions/shared/build.gradle.kts
+++ b/improved-factions/shared/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.kotlin.jvm)
 }
@@ -12,6 +14,12 @@ repositories {
 dependencies {
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
 kotlin {
     jvmToolchain(25)
+    compilerOptions.jvmTarget.set(JvmTarget.JVM_21)
 }

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/commands/executor/CommandExecutor.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/commands/executor/CommandExecutor.kt
@@ -86,7 +86,8 @@ open class CommandExecutor(private val plugin: ImprovedFactionsPlugin) : TabExec
             return emptyList()
         }
 
-        val joinedCommand = createJoinedCommand(originalArgs)
+        val effectiveArgs = resolveAliases(originalArgs)
+        val joinedCommand = createJoinedCommand(effectiveArgs)
         val processor = findProcessor(joinedCommand) ?: return tabCompleteCommands(sender, originalArgs)
 
         if (isProcessorAmbiguous(joinedCommand)) {
@@ -97,7 +98,7 @@ open class CommandExecutor(private val plugin: ImprovedFactionsPlugin) : TabExec
             return emptyList()
         }
 
-        val leftArgs = joinedCommand.replace(processor.label, "").trimStart()
+        val leftArgs = joinedCommand.substring(processor.label.length).trimStart()
         val argsArray = leftArgs.split(" ").toTypedArray()
 
         val rawResults = processor.tabComplete(sender, argsArray)
@@ -114,7 +115,8 @@ open class CommandExecutor(private val plugin: ImprovedFactionsPlugin) : TabExec
         label: String,
         originalArgs: Array<String>,
     ): Boolean {
-        val joinedCommand = createJoinedCommand(originalArgs)
+        val effectiveArgs = resolveAliases(originalArgs)
+        val joinedCommand = createJoinedCommand(effectiveArgs)
         val processor = findProcessor(joinedCommand)
         if (processor == null) {
             sender.sendLocalized("base.commands.unknown-command")
@@ -126,7 +128,7 @@ open class CommandExecutor(private val plugin: ImprovedFactionsPlugin) : TabExec
             return false
         }
 
-        val leftArgs = joinedCommand.replace(processor.label, "").trim()
+        val leftArgs = joinedCommand.substring(processor.label.length).trim()
         val args = leftArgs.split(" ").filter { it.isNotBlank() }.toTypedArray()
 
         val result = runCatching {
@@ -154,10 +156,24 @@ open class CommandExecutor(private val plugin: ImprovedFactionsPlugin) : TabExec
 
     private fun isProcessorAmbiguous(joinedCommand: String) = getPossibleProcessors(joinedCommand) > 1
 
-    private fun getPossibleProcessors(arg: String) = commandProcessors.entries.count { it.key.contains(arg) }
+    private fun getPossibleProcessors(arg: String): Int {
+        val normalized = arg.lowercase()
+        return commandProcessors.keys.count { it == normalized || it.startsWith("$normalized ") }
+    }
 
-    private fun findProcessor(joinedCommand: String) =
-        commandProcessors.entries.firstOrNull { joinedCommand.startsWith(it.key) }?.value
+    private fun findProcessor(joinedCommand: String): CommandProcessor? {
+        val normalized = joinedCommand.lowercase()
+        return commandProcessors.entries.firstOrNull {
+            normalized == it.key || normalized.startsWith("${it.key} ")
+        }?.value
+    }
 
     private fun createJoinedCommand(args: Array<String>): String = args.joinToString(" ")
+
+    private fun resolveAliases(args: Array<String>): Array<String> =
+        if (args.size == 1 && args[0].equals("admin", ignoreCase = true)) {
+            arrayOf("help", "c:admin")
+        } else {
+            args
+        }
 }

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/commands/general/HelpCommand.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/commands/general/HelpCommand.kt
@@ -47,11 +47,12 @@ abstract class HelpCommand : HelpCommandContext() {
             return helpSuccess()
         }
 
-        val processor = commands[command]
+        val normalizedCommand = command.lowercase()
+        val processor = commands[normalizedCommand]
 
         return when {
-            processor == null || command.startsWith("c:") -> {
-                val category = command.removePrefix("c:")
+            processor == null || normalizedCommand.startsWith("c:") -> {
+                val category = normalizedCommand.removePrefix("c:")
                 if (!categoryIndex.containsKey(category)) {
                     return helpCommandNotFound()
                 }
@@ -69,7 +70,10 @@ abstract class HelpCommand : HelpCommandContext() {
 
     private fun printCategoryOverview(sender: CommandSender) {
         sender.sendCommandResult(helpHeader())
-        categoryIndex.keys.forEach { category ->
+        categoryIndex.keys.sorted().forEach { category ->
+            if (categoryIndex[category].orEmpty().none { commands[it]?.canExecute(sender, emptyArray()) == true }) {
+                return@forEach
+            }
             val categoryLocale = categoryLocaleIndex[category] ?: category
             sender.sendCommandResult(
                 helpCategoryOverview(
@@ -106,8 +110,11 @@ abstract class HelpCommand : HelpCommandContext() {
 
     private fun printCategoryDetails(sender: CommandSender, category: String) {
         sender.sendCommandResult(helpHeader())
-        val commands = categoryIndex[category]?.mapNotNull { commands[it] } ?: return
+        val commands = categoryIndex[category]
+            ?.mapNotNull { commands[it] }
+            ?.filter { it.canExecute(sender, emptyArray()) }
+            ?: return
 
-        commands.forEach { printCommandDetails(sender, it) }
+        commands.sortedBy { it.label }.forEach { printCommandDetails(sender, it) }
     }
 }

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/commands/manage/DeleteCommand.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/commands/manage/DeleteCommand.kt
@@ -36,7 +36,7 @@ abstract class DeleteCommand : DeleteCommandContext() {
         val faction = player.factionUser().faction()
             ?: return notInFaction()
 
-        if (!player.factionUser().faction()?.owner?.equals(player.uniqueId)!!) {
+        if (faction.owner != player.uniqueId) {
             return notFactionOwner()
         }
 

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/commands/manage/IconCommand.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/commands/manage/IconCommand.kt
@@ -45,7 +45,7 @@ abstract class IconCommand : IconCommandContext() {
             return notFactionOwner()
         }
 
-        if (factionUser.hasPermission(Permissions.SET_ICON)) {
+        if (!factionUser.hasPermission(Permissions.SET_ICON)) {
             return noPermission()
         }
 

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/commands/rank/SetPermissionCommand.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/commands/rank/SetPermissionCommand.kt
@@ -31,7 +31,7 @@ abstract class SetPermissionCommand : SetPermissionCommandContext() {
             return notInFaction()
         }
 
-        if (player.factionUser().hasPermission(Permissions.MANAGE_PERMISSIONS)) {
+        if (!player.factionUser().hasPermission(Permissions.MANAGE_PERMISSIONS)) {
             return noPermission()
         }
 

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/config/EventDisplayLocation.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/config/EventDisplayLocation.kt
@@ -58,20 +58,6 @@ enum class EventDisplayLocation {
         subMessage: LocalizationKey?,
         placeholders: Map<String, String> = emptyMap()
     ) {
-        when (this) {
-            ACTIONBAR, CHAT -> display(
-                player,
-                subMessage!!,
-                null,
-                placeholders
-            )
-
-            else -> display(
-                player,
-                mainMessage,
-                subMessage,
-                placeholders
-            )
-        }
+        display(player, mainMessage, subMessage, placeholders)
     }
 }

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/factions/Faction.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/factions/Faction.kt
@@ -222,9 +222,10 @@ class Faction(id: EntityID<Int>) : IntEntity(id) {
                 .plus(5, DateTimeUnit.MINUTE)
                 .toLocalDateTime(TimeZone.UTC)
         }
+        val inviteId = invite.id.value
         Bukkit.getScheduler().runTaskLater(
             ImprovedFactionsPlugin.instance,
-            Runnable { loggedTransaction { invite.delete() } },
+            Runnable { loggedTransaction { FactionInvite.findById(inviteId)?.delete() } },
             BaseModule.config.inviteExpiresInMinutes * 60 * 20L
         )
 

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/factions/FactionHandler.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/factions/FactionHandler.kt
@@ -14,6 +14,7 @@ import org.bukkit.Material
 import io.github.toberocat.improvedfactions.api.events.FactionCreateEvent
 import org.jetbrains.exposed.sql.SizedIterable
 import java.util.*
+import java.util.concurrent.CancellationException
 
 /**
  * Created: 04.08.2023
@@ -30,16 +31,19 @@ object FactionHandler {
                 icon = ItemBuilder().title("§e$factionName").material(Material.WOODEN_SWORD)
                     .create(ImprovedFactionsPlugin.instance)
             }
-            createListenersFor(faction)
-
             val ranks = createDefaultRanks(faction.id.value)
 
             faction.defaultRank = ranks.firstOrNull()?.id?.value ?: FactionRankHandler.guestRankId
             faction.join(ownerId, ranks.lastOrNull()?.id?.value ?: FactionRankHandler.guestRankId)
             faction.setAccumulatedPower(faction.maxPower, PowerAccumulationChangeReason.PASSIVE_ENERGY_ACCUMULATION)
+            val event = FactionCreateEvent(faction)
+            Bukkit.getPluginManager().callEvent(event)
+            if (event.isCancelled) {
+                throw CancellationException("Faction creation was cancelled")
+            }
+            createListenersFor(faction)
             return@loggedTransaction faction
         }
-        Bukkit.getPluginManager().callEvent(FactionCreateEvent(faction))
         return faction
     }
 

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/base/BaseModule.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/base/BaseModule.kt
@@ -22,7 +22,6 @@ import io.github.toberocat.improvedfactions.user.factionUser
 import io.github.toberocat.improvedfactions.utils.BStatsCollector
 import io.github.toberocat.improvedfactions.utils.FileUtils
 import io.github.toberocat.improvedfactions.utils.toOfflinePlayer
-import net.kyori.adventure.platform.bukkit.BukkitAudiences
 import org.bukkit.OfflinePlayer
 import org.jetbrains.exposed.sql.Database
 import java.util.logging.Logger
@@ -32,7 +31,6 @@ object BaseModule : Module {
     override val moduleName = MODULE_NAME
     override var isEnabled = false
 
-    lateinit var adventure: BukkitAudiences
     lateinit var config: ImprovedFactionsConfig
     lateinit var database: Database
     lateinit var claimChunkClusters: ClaimClusterDetector
@@ -44,7 +42,6 @@ object BaseModule : Module {
         this.plugin = plugin
         logger = plugin.logger
 
-        adventure = BukkitAudiences.create(plugin)
         claimChunkClusters = ClaimClusterDetector(DatabaseClaimQueryProvider())
         config = ImprovedFactionsConfig.createConfig(plugin)
 
@@ -71,10 +68,6 @@ object BaseModule : Module {
 
     override fun onLoadDatabase(plugin: ImprovedFactionsPlugin) {
         database = DatabaseConnector(plugin).createDatabase()
-    }
-
-    override fun onDisable(plugin: ImprovedFactionsPlugin) {
-        adventure.close()
     }
 
     @PapiPlaceholder("owner", MODULE_NAME, "The owner of the faction")

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/claimparticle/handles/RenderParticlesTask.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/claimparticle/handles/RenderParticlesTask.kt
@@ -56,7 +56,7 @@ class RenderParticlesTask(private val config: ClaimParticleModuleConfig) : Bukki
         )
 
         player.spawnParticle(
-            Particle.REDSTONE,
+            Particle.DUST,
             location,
             config.particleCount,
             config.particleSpread,

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/power/config/PowerManagementConfig.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/power/config/PowerManagementConfig.kt
@@ -34,7 +34,7 @@ data class PowerManagementConfig(
         inactiveAccumulationMultiplier =
             config.getUnsignedDouble("$configPath.accumulation-inactive-multiplier", inactiveAccumulationMultiplier)
         accumulationMultiplier = config.getUnsignedDouble("$configPath.accumulation-multiplier", accumulationMultiplier)
-        inactiveMilliseconds = (config.getEnum<TimeUnit>("$configPath.inactive.unit") ?: TimeUnit.DAYS).toSeconds(
+        inactiveMilliseconds = (config.getEnum<TimeUnit>("$configPath.inactive.unit") ?: TimeUnit.DAYS).toMillis(
             abs(
                 config.getLong("$configPath.inactive.value", 1)
             )

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/power/impl/FactionPowerRaidModuleHandleImpl.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/power/impl/FactionPowerRaidModuleHandleImpl.kt
@@ -19,8 +19,8 @@ const val TICKS_TO_MS = 50
 
 class FactionPowerRaidModuleHandleImpl(private val config: PowerManagementConfig) : FactionPowerRaidModuleHandle {
 
-    private var accumulateTaskId: Int = 0
-    private var claimKeepCostTaskId: Int = 1
+    private var accumulateTaskId: Int? = null
+    private var claimKeepCostTaskId: Int? = null
     private var lastAccumulationMs = System.currentTimeMillis()
     private var lastClaimKeepCostMs = System.currentTimeMillis()
 
@@ -73,8 +73,8 @@ class FactionPowerRaidModuleHandleImpl(private val config: PowerManagementConfig
     fun nextClaimKeepCostCycleTime() = lastClaimKeepCostMs + config.accumulationTickDelay * TICKS_TO_MS
 
     override fun reloadConfig(plugin: ImprovedFactionsPlugin) {
-        Bukkit.getScheduler().cancelTask(accumulateTaskId)
-        Bukkit.getScheduler().cancelTask(claimKeepCostTaskId)
+        accumulateTaskId?.let(Bukkit.getScheduler()::cancelTask)
+        claimKeepCostTaskId?.let(Bukkit.getScheduler()::cancelTask)
 
         accumulateTaskId = Bukkit.getScheduler()
             .runTaskTimer(plugin, ::accumulateAll, config.accumulationTickDelay, config.accumulationTickDelay).taskId
@@ -115,9 +115,11 @@ class FactionPowerRaidModuleHandleImpl(private val config: PowerManagementConfig
         getPowerAccumulated(getActivePowerAccumulation(faction), getInactivePowerAccumulation(faction))
 
     override fun getActivePowerAccumulation(faction: Faction) =
-        (1 + faction.countActiveMembers(config.accumulationTickDelay) / faction.members().count().toDouble()).pow(
-            config.activeAccumulationExponent
-        ) * config.accumulationMultiplier
+        faction.members().count().takeIf { it > 0 }?.let { memberCount ->
+            (1 + faction.countActiveMembers(config.accumulationTickDelay) / memberCount.toDouble()).pow(
+                config.activeAccumulationExponent
+            ) * config.accumulationMultiplier
+        } ?: 0.0
 
 
     override fun getClaimMaintenanceCost(faction: Faction) = getClaimMaintenanceCost(faction.claims().count())

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/relations/database/FactionAllyInvites.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/relations/database/FactionAllyInvites.kt
@@ -19,6 +19,7 @@ object FactionAllyInvites : IntIdTable("faction_ally_invites") {
     val expirationDate = datetime("expiration_date")
 
     fun scheduleInviteExpirations() = FactionAllyInvite.all().forEach {
+        val inviteId = it.id.value
         val ticksTillExpired = (it.expirationDate.toInstant(TimeZone.UTC) - Clock.System.now()).inWholeSeconds * 20
         if (ticksTillExpired <= 0) {
             it.delete()
@@ -26,7 +27,9 @@ object FactionAllyInvites : IntIdTable("faction_ally_invites") {
         }
 
         Bukkit.getScheduler().runTaskLater(
-            ImprovedFactionsPlugin.instance, Runnable { loggedTransaction { it.delete() } }, ticksTillExpired
+            ImprovedFactionsPlugin.instance,
+            Runnable { loggedTransaction { FactionAllyInvite.findById(inviteId)?.delete() } },
+            ticksTillExpired
         )
     }
 }

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/wilderness/commands/WildernessCommand.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/wilderness/commands/WildernessCommand.kt
@@ -56,10 +56,10 @@ abstract class WildernessCommand : WildernessCommandContext() {
     }
 
     private fun teleport(location: Location, player: Player) {
-        if (WildernessModule.config.gainResistance && !player.hasPotionEffect(PotionEffectType.DAMAGE_RESISTANCE)) {
+        if (WildernessModule.config.gainResistance && !player.hasPotionEffect(PotionEffectType.RESISTANCE)) {
             player.addPotionEffect(
                 PotionEffect(
-                    PotionEffectType.DAMAGE_RESISTANCE,
+                    PotionEffectType.RESISTANCE,
                     WildernessModule.config.resistanceDuration * 20,
                     WildernessModule.config.resistanceAmplifier,
                     false,

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/wilderness/config/WildernessModuleConfig.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/wilderness/config/WildernessModuleConfig.kt
@@ -86,7 +86,7 @@ class WildernessModuleConfig(
         if (preventSpawnOverLiquids && location.block.isLiquid) {
             return false
         }
-        if (blacklistedBiomes.contains(location.block.biome.name)) {
+        if (blacklistedBiomes.contains(location.block.biome.key.key.uppercase())) {
             return false
         }
         if (!pluginConfig.allowedWorlds.contains(location.world?.name)) {

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/utils/Extensions.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/utils/Extensions.kt
@@ -5,7 +5,6 @@ import io.github.toberocat.improvedfactions.annotations.command.CommandMeta
 import io.github.toberocat.improvedfactions.annotations.command.GeneratedCommandMeta
 import io.github.toberocat.improvedfactions.commands.CommandProcessor
 import io.github.toberocat.improvedfactions.database.DatabaseManager.loggedTransaction
-import io.github.toberocat.improvedfactions.modules.base.BaseModule
 import io.github.toberocat.improvedfactions.utils.offline.KnownOfflinePlayer
 import io.github.toberocat.improvedfactions.utils.offline.KnownOfflinePlayers
 import io.github.toberocat.toberocore.command.SubCommand
@@ -22,7 +21,7 @@ import kotlin.reflect.full.isSubclassOf
 
 inline fun <T, R> T.compute(computeBlock: (T) -> R) = computeBlock(this)
 
-fun Player.toAudience(): Audience = BaseModule.adventure.player(this)
+fun Player.toAudience(): Audience = this
 
 fun UUID.toOfflinePlayer(): OfflinePlayer = Bukkit.getOfflinePlayer(this)
 

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/utils/particles/TeleportParticles.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/utils/particles/TeleportParticles.kt
@@ -25,7 +25,7 @@ class TeleportParticles(
             val x = center.x + helixRadius * cos(angle)
             val z = center.z + helixRadius * sin(angle)
             val location = Location(center.world, x, center.y + height, z)
-            location.world!!.spawnParticle(Particle.TOTEM, location, 1, 0.0, 0.0, 0.0, 0.0)
+            location.world!!.spawnParticle(Particle.TOTEM_OF_UNDYING, location, 1, 0.0, 0.0, 0.0, 0.0)
         }
     }
 }

--- a/improved-factions/src/main/resources/plugin.yml
+++ b/improved-factions/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: ImprovedFactions
 version: '${version}'
 main: io.github.toberocat.improvedfactions.ImprovedFactionsPlugin
-api-version: '1.18'
+api-version: '26.2'
 softdepend: [ PlaceholderAPI, dynmap, GuiEngine ]
 author: Tobero
 commands:

--- a/improved-factions/src/main/resources/plugin.yml
+++ b/improved-factions/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: ImprovedFactions
 version: '${version}'
 main: io.github.toberocat.improvedfactions.ImprovedFactionsPlugin
-api-version: '26.2'
+api-version: '1.21.11'
 softdepend: [ PlaceholderAPI, dynmap, GuiEngine ]
 author: Tobero
 commands:


### PR DESCRIPTION
## What changed

This updates ImprovedFactions from the old Spigot 1.18 build target to Paper 1.21.11 with Java 21-compatible bytecode. Gradle, Kotlin, KSP and Shadow were updated, along with API calls that changed in current Paper releases.

`/faction admin` now opens the admin help section correctly. Help links use exact command boundaries, work regardless of case, and only show commands the sender can actually use.

The review also found and fixed several runtime problems:

- icon and rank permission checks were backwards
- cancelled faction creation could still leave database records behind
- expired player and ally invites could delete stale database objects
- power inactivity used seconds where milliseconds were expected
- raid tasks could cancel task IDs that were never scheduled
- event messages could discard the title or force a missing subtitle
- faction deletion could fail while checking ownership
- active power calculation could divide by zero

## Why

The project still compiled against APIs from Minecraft 1.18. Several renamed particles, effects and biome methods needed updating for 1.21.11, while the older build plugins could not package the updated project reliably. The command parser also treated partial prefixes as full commands, which is why the admin help buttons did not resolve consistently.

## Compatibility

The plugin now compiles against `paper-api:1.21.11-R0.1-SNAPSHOT`, declares `api-version: 1.21.11`, and emits Java 21 bytecode so it can load on Paper and Purpur 1.21.11.

## Checks

- `gradlew clean build`
- full project test task
- inspected the shaded JAR for `plugin.yml`, SQLite and Exposed
- confirmed the packaged API version is 1.21.11
- confirmed the compiled class version is Java 21
