### PR TITLE
Update Paper, Java, and test dependencies

### DIFF
--- a/.github/workflows/build-wiki.yml
+++ b/.github/workflows/build-wiki.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 17
+      - name: Set up JDK 25
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '25'
           distribution: 'temurin'
           cache: gradle
 

--- a/.github/workflows/publish-nightly-gh-release.yml
+++ b/.github/workflows/publish-nightly-gh-release.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
 
       - name: Setup Gradle
@@ -60,10 +60,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
 
       - name: Ensure Gradle Wrapper is executable

--- a/.github/workflows/publish-to-modrinth-stable-channel.yml
+++ b/.github/workflows/publish-to-modrinth-stable-channel.yml
@@ -10,10 +10,10 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 17
+      - name: Set up JDK 25
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
       - name: Run the Maven build for ImprovedFactionsBase

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
 
       - name: Setup Gradle

--- a/improved-factions/build.gradle.kts
+++ b/improved-factions/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.google.devtools.ksp.gradle.KspTask
 import java.nio.file.Files
 import java.util.*
 
@@ -6,7 +5,7 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.devtools.ksp)
     id("maven-publish")
-    id("com.gradleup.shadow") version "9.0.0-beta13"
+    id("com.gradleup.shadow") version "9.6.1"
     id("com.github.ben-manes.versions") version "0.52.0"
     id("org.jetbrains.dokka") version "2.1.0"
 }
@@ -18,26 +17,20 @@ if (versionPropsFile.exists()) {
     versionProps.load(versionPropsFile.inputStream())
 }
 
-val buildIncrement = (versionProps["buildIncrement"]?.toString()?.toInt() ?: 1) + 1
+val buildIncrement = versionProps["buildIncrement"]?.toString()?.toInt() ?: 1
 val versionName = versionProps["versionName"]!!.toString()
-
-versionProps["buildIncrement"] = buildIncrement.toString()
-versionProps["versionName"] = versionName
-
-versionProps.store(versionPropsFile.outputStream(), null)
 
 
 group = "io.github.toberocat.improved-factions"
 version = versionName
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 }
 
 repositories {
     mavenCentral()
-    maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
     maven("https://jitpack.io")
     maven("https://repo.extendedclip.com/content/repositories/placeholderapi/")
     maven("https://maven.paulem.net/releases/")
@@ -49,8 +42,8 @@ repositories {
 dependencies {
     implementation(project(":shared"))
 
-    // Spigot API
-    compileOnly(libs.spigot.api)
+    // Paper API
+    compileOnly(libs.paper.api)
 
     // Exposed ORM
     implementation(libs.exposed.core)
@@ -73,7 +66,6 @@ dependencies {
     compileOnly(libs.guiengine)
     implementation(libs.adventure.text.minimessage)
     implementation(libs.adventure.text.serializer.legacy)
-    implementation(libs.kyori.adventure.platform.bukkit)
     implementation(libs.bstats.bukkit)
 
     // Provided dependencies
@@ -99,7 +91,7 @@ tasks.named<Copy>("processResources") {
     }
 }
 
-tasks.withType<KspTask>().configureEach {
+tasks.matching { it.name.startsWith("ksp") }.configureEach {
     dependsOn(generateBuildConfig)
 }
 
@@ -115,9 +107,6 @@ dokka {
 
 tasks.shadowJar {
     archiveFileName.set("${project.name}-${project.version}.jar")
-    if (System.getenv("CI") == null && System.getenv("JITPACK") == null) {
-        destinationDirectory.set(file("../server/plugins"))
-    }
     relocate("com.fasterxml.jackson", "io.github.toberocat.relocated.jackson")
     relocate("net.kyori", "io.github.toberocat.relocated.kyori")
     relocate("dev.s7a", "io.github.toberocat.relocated.base64itemstack")
@@ -131,6 +120,10 @@ tasks.shadowJar {
 }
 
 tasks {
+    jar {
+        enabled = false
+    }
+
     build {
         dependsOn(shadowJar)
     }
@@ -151,7 +144,7 @@ tasks {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 
     sourceSets.main {
         kotlin.srcDir("build/generated/ksp/main/kotlin")

--- a/improved-factions/build.gradle.kts
+++ b/improved-factions/build.gradle.kts
@@ -1,5 +1,6 @@
 import java.nio.file.Files
 import java.util.*
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
@@ -25,8 +26,8 @@ group = "io.github.toberocat.improved-factions"
 version = versionName
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_25
-    targetCompatibility = JavaVersion.VERSION_25
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 repositories {
@@ -145,6 +146,7 @@ tasks {
 
 kotlin {
     jvmToolchain(25)
+    compilerOptions.jvmTarget.set(JvmTarget.JVM_21)
 
     sourceSets.main {
         kotlin.srcDir("build/generated/ksp/main/kotlin")

--- a/improved-factions/build.gradle.kts
+++ b/improved-factions/build.gradle.kts
@@ -122,7 +122,6 @@ tasks.shadowJar {
         destinationDirectory.set(file("../server/plugins"))
     }
     relocate("com.fasterxml.jackson", "io.github.toberocat.relocated.jackson")
-    relocate("net.kyori", "io.github.toberocat.relocated.kyori")
     relocate("dev.s7a", "io.github.toberocat.relocated.base64itemstack")
     relocate("org.bstats", "io.github.toberocat.relocated.bstats")
     relocate("com.jeff_media.updatechecker", "io.github.toberocat.relocated.updatechecker")

--- a/improved-factions/build.gradle.kts
+++ b/improved-factions/build.gradle.kts
@@ -116,6 +116,7 @@ dokka {
 }
 
 tasks.shadowJar {
+    configurations = listOf(project.configurations.runtimeClasspath.get())
     archiveFileName.set("${project.name}-${project.version}.jar")
     if (System.getenv("CI") == null && System.getenv("JITPACK") == null) {
         destinationDirectory.set(file("../server/plugins"))

--- a/improved-factions/build.gradle.kts
+++ b/improved-factions/build.gradle.kts
@@ -7,8 +7,8 @@ plugins {
     alias(libs.plugins.devtools.ksp)
     id("maven-publish")
     id("com.gradleup.shadow") version "9.6.1"
-    id("com.github.ben-manes.versions") version "0.52.0"
-    id("org.jetbrains.dokka") version "2.1.0"
+    id("io.github.ben-manes.versions") version "0.60.0"
+    id("org.jetbrains.dokka") version "2.2.0"
 }
 
 val versionPropsFile = file("version.properties")
@@ -18,16 +18,21 @@ if (versionPropsFile.exists()) {
     versionProps.load(versionPropsFile.inputStream())
 }
 
-val buildIncrement = versionProps["buildIncrement"]?.toString()?.toInt() ?: 1
+val buildIncrement = (versionProps["buildIncrement"]?.toString()?.toInt() ?: 1) + 1
 val versionName = versionProps["versionName"]!!.toString()
+
+versionProps["buildIncrement"] = buildIncrement.toString()
+versionProps["versionName"] = versionName
+
+versionProps.store(versionPropsFile.outputStream(), null)
 
 
 group = "io.github.toberocat.improved-factions"
 version = versionName
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 }
 
 repositories {
@@ -67,6 +72,7 @@ dependencies {
     compileOnly(libs.guiengine)
     implementation(libs.adventure.text.minimessage)
     implementation(libs.adventure.text.serializer.legacy)
+    implementation(libs.kyori.adventure.platform.bukkit)
     implementation(libs.bstats.bukkit)
 
     // Provided dependencies
@@ -77,6 +83,7 @@ dependencies {
     testImplementation(libs.kotlin.test.junit)
     testImplementation(libs.kotlin.test)
     testImplementation(libs.junit.jupiter.params)
+    testImplementation(libs.paper.api)
     testImplementation(libs.mockbukkit)
     testImplementation(libs.snakeyaml)
     testImplementation(libs.gson)
@@ -92,8 +99,10 @@ tasks.named<Copy>("processResources") {
     }
 }
 
-tasks.matching { it.name.startsWith("ksp") }.configureEach {
-    dependsOn(generateBuildConfig)
+tasks.configureEach {
+    if (name == "kspKotlin") {
+        dependsOn(generateBuildConfig)
+    }
 }
 
 dokka {
@@ -108,6 +117,9 @@ dokka {
 
 tasks.shadowJar {
     archiveFileName.set("${project.name}-${project.version}.jar")
+    if (System.getenv("CI") == null && System.getenv("JITPACK") == null) {
+        destinationDirectory.set(file("../server/plugins"))
+    }
     relocate("com.fasterxml.jackson", "io.github.toberocat.relocated.jackson")
     relocate("net.kyori", "io.github.toberocat.relocated.kyori")
     relocate("dev.s7a", "io.github.toberocat.relocated.base64itemstack")
@@ -121,10 +133,6 @@ tasks.shadowJar {
 }
 
 tasks {
-    jar {
-        enabled = false
-    }
-
     build {
         dependsOn(shadowJar)
     }
@@ -146,7 +154,7 @@ tasks {
 
 kotlin {
     jvmToolchain(25)
-    compilerOptions.jvmTarget.set(JvmTarget.JVM_21)
+    compilerOptions.jvmTarget.set(JvmTarget.JVM_25)
 
     sourceSets.main {
         kotlin.srcDir("build/generated/ksp/main/kotlin")

--- a/improved-factions/code-generation/build.gradle.kts
+++ b/improved-factions/code-generation/build.gradle.kts
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-    implementation("com.google.devtools.ksp:symbol-processing-api:2.0.21-1.0.25")
+    implementation("com.google.devtools.ksp:symbol-processing-api:2.3.9")
     implementation(project(":shared"))
 }

--- a/improved-factions/code-generation/build.gradle.kts
+++ b/improved-factions/code-generation/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.kotlin.jvm)
 }
@@ -9,4 +11,9 @@ repositories {
 dependencies {
     implementation("com.google.devtools.ksp:symbol-processing-api:${libs.versions.ksp.version.get()}")
     implementation(project(":shared"))
+}
+
+kotlin {
+    jvmToolchain(25)
+    compilerOptions.jvmTarget.set(JvmTarget.JVM_25)
 }

--- a/improved-factions/code-generation/build.gradle.kts
+++ b/improved-factions/code-generation/build.gradle.kts
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-    implementation("com.google.devtools.ksp:symbol-processing-api:2.3.9")
+    implementation("com.google.devtools.ksp:symbol-processing-api:${libs.versions.ksp.version.get()}")
     implementation(project(":shared"))
 }

--- a/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/localization/LocalizationReader.kt
+++ b/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/localization/LocalizationReader.kt
@@ -17,6 +17,7 @@ class LocalizationReader(private val languageFolder: File, private val logger: K
         val propertiesFileName = "messages_en_US.properties"
         val properties = Properties()
         val file = File(languageFolder, propertiesFileName)
+
         if (!file.exists()) {
             logger.error("Localization file $propertiesFileName not found.")
             return properties

--- a/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/permission/generator/PermissionDocumentationGenerator.kt
+++ b/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/permission/generator/PermissionDocumentationGenerator.kt
@@ -2,13 +2,13 @@ package io.github.toberocat.improvedfactions.permission.generator
 
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.KSPLogger
-import io.github.toberocat.improvedfactions.annotations.permission.Permission
 import io.github.toberocat.improvedfactions.utils.writeDocumentation
+import io.github.toberocat.improvedfactions.permission.visitor.PermissionData
 
 class PermissionDocumentationGenerator(
     private val logger: KSPLogger,
     private val codeGenerator: CodeGenerator,
-    private val permissions: List<Permission>
+    private val permissions: List<PermissionData>
 ) {
 
     fun createPermissionsMd() {
@@ -25,7 +25,7 @@ class PermissionDocumentationGenerator(
         logger.info("Generated permissions.md successfully.")
     }
 
-    private fun buildMarkdown(permissions: List<Permission>): String {
+    private fun buildMarkdown(permissions: List<PermissionData>): String {
         val markdown = StringBuilder()
         markdown.appendLine("# Permissions")
         markdown.appendLine()

--- a/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/permission/generator/PermissionPluginYmlGenerator.kt
+++ b/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/permission/generator/PermissionPluginYmlGenerator.kt
@@ -1,13 +1,13 @@
 package io.github.toberocat.improvedfactions.permission.generator
 
 import com.google.devtools.ksp.processing.KSPLogger
-import io.github.toberocat.improvedfactions.annotations.permission.Permission
+import io.github.toberocat.improvedfactions.permission.visitor.PermissionData
 import java.io.File
 import java.nio.file.Files
 
 class PermissionPluginYmlGenerator(
     private val logger: KSPLogger,
-    private val permissions: List<Permission>
+    private val permissions: List<PermissionData>
 ) {
 
     fun appendYmlToPluginYml(pluginYmlFile: File) {
@@ -45,7 +45,7 @@ class PermissionPluginYmlGenerator(
         }
     }
 
-    private fun buildYaml(permissions: List<Permission>): String {
+    private fun buildYaml(permissions: List<PermissionData>): String {
         val root = PermissionNode("permissions")
 
         for (permission in permissions) {

--- a/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/permission/generator/PermissionPluginYmlGenerator.kt
+++ b/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/permission/generator/PermissionPluginYmlGenerator.kt
@@ -74,7 +74,11 @@ class PermissionPluginYmlGenerator(
 
     private fun serializeNode(node: PermissionNode, builder: StringBuilder, indent: Int) {
         val indentStr = "  ".repeat(indent)
-        builder.append("$indentStr${node.name}: ${node.inlined}\n")
+        builder.append("$indentStr${node.name}:")
+        if (node.inlined.isNotEmpty()) {
+            builder.append(" ${node.inlined}")
+        }
+        builder.append('\n')
 
         if (node.default != null) {
             val defaultIndentStr = "  ".repeat(indent + 1)

--- a/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/permission/processor/PermissionProcessor.kt
+++ b/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/permission/processor/PermissionProcessor.kt
@@ -7,6 +7,7 @@ import io.github.toberocat.improvedfactions.annotations.permission.PermissionCon
 import io.github.toberocat.improvedfactions.permission.generator.PermissionDocumentationGenerator
 import io.github.toberocat.improvedfactions.permission.generator.PermissionPluginYmlGenerator
 import io.github.toberocat.improvedfactions.permission.visitor.PermissionVisitor
+import io.github.toberocat.improvedfactions.permission.visitor.PermissionData
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -17,7 +18,7 @@ class PermissionProcessor(
     private val logger: KSPLogger,
     private val pluginYmlFile: File
 ) : SymbolProcessor {
-    private val permissions = mutableListOf<Permission>()
+    private val permissions = mutableListOf<PermissionData>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
         val symbols = resolver.getSymbolsWithAnnotation(Permission::class.qualifiedName!!)
@@ -34,10 +35,8 @@ class PermissionProcessor(
     }
 
     override fun finish() {
-        PermissionPluginYmlGenerator(logger, permissions).appendYmlToPluginYml(pluginYmlFile)
-
         // Add factions.* permission for documentation generation
-        permissions.add(Permission("factions.*", PermissionConfigurations.OP_ONLY))
+        permissions.add(PermissionData("factions.*", PermissionConfigurations.OP_ONLY))
         PermissionDocumentationGenerator(logger, codeGenerator, permissions).createPermissionsMd()
     }
 }

--- a/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/permission/visitor/PermissionVisitor.kt
+++ b/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/permission/visitor/PermissionVisitor.kt
@@ -3,13 +3,19 @@ package io.github.toberocat.improvedfactions.permission.visitor
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSVisitorVoid
 import io.github.toberocat.improvedfactions.annotations.permission.Permission
+import io.github.toberocat.improvedfactions.annotations.permission.PermissionConfigurations
 import io.github.toberocat.improvedfactions.utils.findAnnotation
 
 class PermissionVisitor : KSVisitorVoid() {
-    val permissions = mutableListOf<Permission>()
+    val permissions = mutableListOf<PermissionData>()
 
     override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: Unit) {
         val permissionAnnotation = function.findAnnotation<Permission>() ?: return
-        permissions.add(permissionAnnotation)
+        permissions.add(PermissionData(permissionAnnotation.value, permissionAnnotation.config))
     }
 }
+
+data class PermissionData(
+    val value: String,
+    val config: PermissionConfigurations,
+)

--- a/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/placeholder/generator/PlaceholderDocumentationGenerator.kt
+++ b/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/placeholder/generator/PlaceholderDocumentationGenerator.kt
@@ -1,12 +1,12 @@
 package io.github.toberocat.improvedfactions.placeholder.generator
 
 import com.google.devtools.ksp.processing.CodeGenerator
-import io.github.toberocat.improvedfactions.annotations.papi.PapiPlaceholder
+import io.github.toberocat.improvedfactions.placeholder.visitor.PlaceholderData
 import io.github.toberocat.improvedfactions.utils.writeDocumentation
 
 class PlaceholderDocumentationGenerator(
     private val codeGenerator: CodeGenerator,
-    private val placeholders: MutableList<PapiPlaceholder>
+    private val placeholders: MutableList<PlaceholderData>
 ) {
     fun createPlaceholdersMd() {
         codeGenerator.writeDocumentation(

--- a/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/placeholder/processor/PlaceholderProcessor.kt
+++ b/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/placeholder/processor/PlaceholderProcessor.kt
@@ -7,6 +7,7 @@ import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.KSAnnotated
 import io.github.toberocat.improvedfactions.annotations.papi.PapiPlaceholder
 import io.github.toberocat.improvedfactions.placeholder.generator.PlaceholderDocumentationGenerator
+import io.github.toberocat.improvedfactions.placeholder.visitor.PlaceholderData
 import io.github.toberocat.improvedfactions.placeholder.visitor.PlaceholderVisitor
 
 class PlaceholderProcessor(
@@ -14,7 +15,7 @@ class PlaceholderProcessor(
     private val logger: KSPLogger,
 ) : SymbolProcessor {
 
-    private val placeholders = mutableListOf<PapiPlaceholder>()
+    private val placeholders = mutableListOf<PlaceholderData>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
         val symbols = resolver.getSymbolsWithAnnotation(PapiPlaceholder::class.qualifiedName!!)

--- a/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/placeholder/visitor/PlaceholderVisitor.kt
+++ b/improved-factions/code-generation/src/main/kotlin/io/github/toberocat/improvedfactions/placeholder/visitor/PlaceholderVisitor.kt
@@ -6,10 +6,18 @@ import io.github.toberocat.improvedfactions.annotations.papi.PapiPlaceholder
 import io.github.toberocat.improvedfactions.utils.findAnnotations
 
 class PlaceholderVisitor : KSVisitorVoid() {
-    val placeholders = mutableListOf<PapiPlaceholder>()
+    val placeholders = mutableListOf<PlaceholderData>()
 
     override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: Unit) {
         val annotation = function.findAnnotations<PapiPlaceholder>() ?: return
-        placeholders.addAll(annotation)
+        placeholders.addAll(annotation.map {
+            PlaceholderData(it.value, it.module, it.description)
+        })
     }
 }
+
+data class PlaceholderData(
+    val value: String,
+    val module: String,
+    val description: String,
+)

--- a/improved-factions/gradle/libs.versions.toml
+++ b/improved-factions/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin-version = "2.3.20"
 ksp-version = "2.3.9"
-paper-version = "26.2.build.+"
+paper-version = "1.21.11-R0.1-SNAPSHOT"
 exposed-version = "0.61.0"
 jackson-version = "2.19.0"
 kotlinx-datetime-version = "0.6.2"

--- a/improved-factions/gradle/libs.versions.toml
+++ b/improved-factions/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-kotlin-version = "2.0.21"
-ksp-version = "2.0.21-1.0.25"
-spigot-version = "1.18.1-R0.1-SNAPSHOT"
+kotlin-version = "2.3.20"
+ksp-version = "2.3.9"
+paper-version = "26.2.build.+"
 exposed-version = "0.61.0"
 jackson-version = "2.19.0"
 kotlinx-datetime-version = "0.6.2"
@@ -12,7 +12,6 @@ spigot-update-checker-version = "3.0.4"
 guiengine-version = "6c00296e4c"
 adventure-text-minimessages-version = "4.24.0"
 adventure-text-serializer-legacy-version = "4.24.0"
-kyori-adventure-platform-bukkit-version = "4.4.1"
 bstats-bukkit-version = "3.1.0"
 placeholder-api-version = "2.11.6"
 dynmap-api-version = "3.7-beta-6"
@@ -27,7 +26,7 @@ kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit5", versio
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin-version" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-version" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit-jupiter-params-version" }
-spigot-api = { module = "org.spigotmc:spigot-api", version.ref = "spigot-version" }
+paper-api = { module = "io.papermc.paper:paper-api", version.ref = "paper-version" }
 exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed-version" }
 exposed-jdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed-version" }
 exposed-dao = { module = "org.jetbrains.exposed:exposed-dao", version.ref = "exposed-version" }
@@ -43,7 +42,6 @@ spigot-update-checker = { module = "com.jeff_media:SpigotUpdateChecker", version
 guiengine = { module = "com.github.ToberoCat:GuiEngine", version.ref = "guiengine-version" }
 adventure-text-minimessage = { module = "net.kyori:adventure-text-minimessage", version.ref = "adventure-text-minimessages-version" }
 adventure-text-serializer-legacy = { module = "net.kyori:adventure-text-serializer-legacy", version.ref = "adventure-text-serializer-legacy-version" }
-kyori-adventure-platform-bukkit = { module = "net.kyori:adventure-platform-bukkit", version.ref = "kyori-adventure-platform-bukkit-version" }
 bstats-bukkit = { module = "org.bstats:bstats-bukkit", version.ref = "bstats-bukkit-version" }
 placeholderapi = { module = "me.clip:placeholderapi", version.ref = "placeholder-api-version" }
 dynmap-api = { module = "us.dynmap:DynmapCoreAPI", version.ref = "dynmap-api-version" }

--- a/improved-factions/gradle/libs.versions.toml
+++ b/improved-factions/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin-version = "2.3.20"
-ksp-version = "2.3.9"
+ksp-version = "2.3.11"
 paper-version = "1.21.11-R0.1-SNAPSHOT"
 exposed-version = "0.61.0"
 jackson-version = "2.19.0"

--- a/improved-factions/gradle/libs.versions.toml
+++ b/improved-factions/gradle/libs.versions.toml
@@ -1,24 +1,25 @@
 [versions]
 kotlin-version = "2.3.20"
 ksp-version = "2.3.11"
-paper-version = "1.21.11-R0.1-SNAPSHOT"
+paper-version = "26.1.2.build.72-stable"
 exposed-version = "0.61.0"
-jackson-version = "2.19.0"
+jackson-version = "2.22.1"
 kotlinx-datetime-version = "0.6.2"
 toberocore-version = "be356f9253"
-sqlite-jdbc-version = "3.49.1.0"
-h2-version = "2.3.232"
+sqlite-jdbc-version = "3.53.2.1"
+h2-version = "2.4.240"
 spigot-update-checker-version = "3.0.4"
-guiengine-version = "6c00296e4c"
-adventure-text-minimessages-version = "4.24.0"
-adventure-text-serializer-legacy-version = "4.24.0"
-bstats-bukkit-version = "3.1.0"
-placeholder-api-version = "2.11.6"
+guiengine-version = "1.4.3"
+adventure-text-minimessages-version = "4.26.1"
+adventure-text-serializer-legacy-version = "4.26.1"
+kyori-adventure-platform-bukkit-version = "4.4.1"
+bstats-bukkit-version = "3.2.1"
+placeholder-api-version = "2.12.3"
 dynmap-api-version = "3.7-beta-6"
-mockbukkit-version = "4.49.0"
-snakeyaml-version = "2.4"
-gson-version = "2.13.1"
-logback-classic-version = "1.5.18"
+mockbukkit-version = "4.115.0"
+snakeyaml-version = "2.6"
+gson-version = "2.14.0"
+logback-classic-version = "1.6.1"
 junit-jupiter-params-version = "5.11.0"
 
 [libraries]
@@ -42,10 +43,11 @@ spigot-update-checker = { module = "com.jeff_media:SpigotUpdateChecker", version
 guiengine = { module = "com.github.ToberoCat:GuiEngine", version.ref = "guiengine-version" }
 adventure-text-minimessage = { module = "net.kyori:adventure-text-minimessage", version.ref = "adventure-text-minimessages-version" }
 adventure-text-serializer-legacy = { module = "net.kyori:adventure-text-serializer-legacy", version.ref = "adventure-text-serializer-legacy-version" }
+kyori-adventure-platform-bukkit = { module = "net.kyori:adventure-platform-bukkit", version.ref = "kyori-adventure-platform-bukkit-version" }
 bstats-bukkit = { module = "org.bstats:bstats-bukkit", version.ref = "bstats-bukkit-version" }
 placeholderapi = { module = "me.clip:placeholderapi", version.ref = "placeholder-api-version" }
 dynmap-api = { module = "us.dynmap:DynmapCoreAPI", version.ref = "dynmap-api-version" }
-mockbukkit = { module = "org.mockbukkit.mockbukkit:mockbukkit-v1.21", version.ref = "mockbukkit-version" }
+mockbukkit = { module = "org.mockbukkit.mockbukkit:mockbukkit-v26.1.2", version.ref = "mockbukkit-version" }
 snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "snakeyaml-version" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson-version" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback-classic-version" }

--- a/improved-factions/gradle/wrapper/gradle-wrapper.properties
+++ b/improved-factions/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Sep 08 15:07:49 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/improved-factions/settings.gradle.kts
+++ b/improved-factions/settings.gradle.kts
@@ -9,6 +9,5 @@ plugins {
 }
 
 rootProject.name = "ImprovedFactions"
-include("improved-factions")
 include("shared")
 include("code-generation")

--- a/improved-factions/shared/build.gradle.kts
+++ b/improved-factions/shared/build.gradle.kts
@@ -13,5 +13,5 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(25)
 }

--- a/improved-factions/shared/build.gradle.kts
+++ b/improved-factions/shared/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.kotlin.jvm)
 }
@@ -12,6 +14,12 @@ repositories {
 dependencies {
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
 kotlin {
     jvmToolchain(25)
+    compilerOptions.jvmTarget.set(JvmTarget.JVM_21)
 }

--- a/improved-factions/shared/build.gradle.kts
+++ b/improved-factions/shared/build.gradle.kts
@@ -15,11 +15,11 @@ dependencies {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
 }
 
 kotlin {
     jvmToolchain(25)
-    compilerOptions.jvmTarget.set(JvmTarget.JVM_21)
+    compilerOptions.jvmTarget.set(JvmTarget.JVM_25)
 }

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/commands/executor/CommandExecutor.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/commands/executor/CommandExecutor.kt
@@ -93,7 +93,8 @@ open class CommandExecutor(private val plugin: ImprovedFactionsPlugin) : TabExec
             return emptyList()
         }
 
-        val joinedCommand = createJoinedCommand(originalArgs)
+        val effectiveArgs = resolveAliases(originalArgs)
+        val joinedCommand = createJoinedCommand(effectiveArgs)
         val processor = findProcessor(joinedCommand) ?: return tabCompleteCommands(sender, originalArgs)
 
         if (isProcessorAmbiguous(joinedCommand)) {
@@ -104,7 +105,7 @@ open class CommandExecutor(private val plugin: ImprovedFactionsPlugin) : TabExec
             return emptyList()
         }
 
-        val leftArgs = joinedCommand.replace(processor.label, "").trimStart()
+        val leftArgs = joinedCommand.substring(processor.label.length).trimStart()
         val argsArray = leftArgs.split(" ").toTypedArray()
 
         val rawResults = processor.tabComplete(sender, argsArray)
@@ -121,7 +122,8 @@ open class CommandExecutor(private val plugin: ImprovedFactionsPlugin) : TabExec
         label: String,
         originalArgs: Array<String>,
     ): Boolean {
-        val joinedCommand = createJoinedCommand(originalArgs)
+        val effectiveArgs = resolveAliases(originalArgs)
+        val joinedCommand = createJoinedCommand(effectiveArgs)
         val processor = findProcessor(joinedCommand)
         if (processor == null) {
             sender.sendLocalized("base.commands.unknown-command")
@@ -133,7 +135,7 @@ open class CommandExecutor(private val plugin: ImprovedFactionsPlugin) : TabExec
             return false
         }
 
-        val leftArgs = joinedCommand.replace(processor.label, "").trim()
+        val leftArgs = joinedCommand.substring(processor.label.length).trim()
         val args = leftArgs.split(" ").filter { it.isNotBlank() }.toTypedArray()
 
         val result = runCatching {
@@ -168,10 +170,24 @@ open class CommandExecutor(private val plugin: ImprovedFactionsPlugin) : TabExec
 
     private fun isProcessorAmbiguous(joinedCommand: String) = getPossibleProcessors(joinedCommand) > 1
 
-    private fun getPossibleProcessors(arg: String) = commandProcessors.entries.count { it.key.contains(arg) }
+    private fun getPossibleProcessors(arg: String): Int {
+        val normalized = arg.lowercase()
+        return commandProcessors.keys.count { it == normalized || it.startsWith("$normalized ") }
+    }
 
-    private fun findProcessor(joinedCommand: String) =
-        commandProcessors.entries.firstOrNull { joinedCommand.startsWith(it.key) }?.value
+    private fun findProcessor(joinedCommand: String): CommandProcessor? {
+        val normalized = joinedCommand.lowercase()
+        return commandProcessors.entries.firstOrNull {
+            normalized == it.key || normalized.startsWith("${it.key} ")
+        }?.value
+    }
 
     private fun createJoinedCommand(args: Array<String>): String = args.joinToString(" ")
+
+    private fun resolveAliases(args: Array<String>): Array<String> =
+        if (args.size == 1 && args[0].equals("admin", ignoreCase = true)) {
+            arrayOf("help", "c:admin")
+        } else {
+            args
+        }
 }

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/commands/general/HelpCommand.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/commands/general/HelpCommand.kt
@@ -47,11 +47,12 @@ abstract class HelpCommand : HelpCommandContext() {
             return helpSuccess()
         }
 
-        val processor = commands[command]
+        val normalizedCommand = command.lowercase()
+        val processor = commands[normalizedCommand]
 
         return when {
-            processor == null || command.startsWith("c:") -> {
-                val category = command.removePrefix("c:")
+            processor == null || normalizedCommand.startsWith("c:") -> {
+                val category = normalizedCommand.removePrefix("c:")
                 if (!categoryIndex.containsKey(category)) {
                     return helpCommandNotFound()
                 }
@@ -69,7 +70,10 @@ abstract class HelpCommand : HelpCommandContext() {
 
     private fun printCategoryOverview(sender: CommandSender) {
         sender.sendCommandResult(helpHeader())
-        categoryIndex.keys.forEach { category ->
+        categoryIndex.keys.sorted().forEach { category ->
+            if (categoryIndex[category].orEmpty().none { commands[it]?.canExecute(sender, emptyArray()) == true }) {
+                return@forEach
+            }
             val categoryLocale = categoryLocaleIndex[category] ?: category
             sender.sendCommandResult(
                 helpCategoryOverview(
@@ -106,8 +110,11 @@ abstract class HelpCommand : HelpCommandContext() {
 
     private fun printCategoryDetails(sender: CommandSender, category: String) {
         sender.sendCommandResult(helpHeader())
-        val commands = categoryIndex[category]?.mapNotNull { commands[it] } ?: return
+        val commands = categoryIndex[category]
+            ?.mapNotNull { commands[it] }
+            ?.filter { it.canExecute(sender, emptyArray()) }
+            ?: return
 
-        commands.forEach { printCommandDetails(sender, it) }
+        commands.sortedBy { it.label }.forEach { printCommandDetails(sender, it) }
     }
 }

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/commands/manage/DeleteCommand.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/commands/manage/DeleteCommand.kt
@@ -36,7 +36,7 @@ abstract class DeleteCommand : DeleteCommandContext() {
         val faction = player.factionUser().faction()
             ?: return notInFaction()
 
-        if (!player.factionUser().faction()?.owner?.equals(player.uniqueId)!!) {
+        if (faction.owner != player.uniqueId) {
             return notFactionOwner()
         }
 

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/commands/manage/IconCommand.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/commands/manage/IconCommand.kt
@@ -45,7 +45,7 @@ abstract class IconCommand : IconCommandContext() {
             return notFactionOwner()
         }
 
-        if (factionUser.hasPermission(Permissions.SET_ICON)) {
+        if (!factionUser.hasPermission(Permissions.SET_ICON)) {
             return noPermission()
         }
 

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/commands/rank/SetPermissionCommand.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/commands/rank/SetPermissionCommand.kt
@@ -31,7 +31,7 @@ abstract class SetPermissionCommand : SetPermissionCommandContext() {
             return notInFaction()
         }
 
-        if (player.factionUser().hasPermission(Permissions.MANAGE_PERMISSIONS)) {
+        if (!player.factionUser().hasPermission(Permissions.MANAGE_PERMISSIONS)) {
             return noPermission()
         }
 

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/config/EventDisplayLocation.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/config/EventDisplayLocation.kt
@@ -58,20 +58,6 @@ enum class EventDisplayLocation {
         subMessage: LocalizationKey?,
         placeholders: Map<String, String> = emptyMap()
     ) {
-        when (this) {
-            ACTIONBAR, CHAT -> display(
-                player,
-                subMessage!!,
-                null,
-                placeholders
-            )
-
-            else -> display(
-                player,
-                mainMessage,
-                subMessage,
-                placeholders
-            )
-        }
+        display(player, mainMessage, subMessage, placeholders)
     }
 }

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/database/DatabaseManager.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/database/DatabaseManager.kt
@@ -14,7 +14,10 @@ import io.github.toberocat.improvedfactions.user.FactionUsers
 import io.github.toberocat.improvedfactions.utils.offline.KnownOfflinePlayers
 import io.github.toberocat.improvedfactions.utils.options.limit.PlayerUsageLimits
 import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.vendors.SQLiteDialect
 
 object DatabaseManager {
 
@@ -52,5 +55,9 @@ object DatabaseManager {
     }
 
     fun createTables(vararg tables: Table) =
-        SchemaUtils.createMissingTablesAndColumns(*tables, withLogs = verboseLogging)
+        if (TransactionManager.currentOrNull()?.db?.dialect is SQLiteDialect) {
+            SchemaUtils.create(*tables)
+        } else {
+            SchemaUtils.createMissingTablesAndColumns(*tables, withLogs = verboseLogging)
+        }
 }

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/factions/Faction.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/factions/Faction.kt
@@ -222,9 +222,10 @@ class Faction(id: EntityID<Int>) : IntEntity(id) {
                 .plus(5, DateTimeUnit.MINUTE)
                 .toLocalDateTime(TimeZone.UTC)
         }
+        val inviteId = invite.id.value
         Bukkit.getScheduler().runTaskLater(
             ImprovedFactionsPlugin.instance,
-            Runnable { loggedTransaction { invite.delete() } },
+            Runnable { loggedTransaction { FactionInvite.findById(inviteId)?.delete() } },
             BaseModule.config.inviteExpiresInMinutes * 60 * 20L
         )
 

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/factions/FactionHandler.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/factions/FactionHandler.kt
@@ -14,6 +14,7 @@ import org.bukkit.Material
 import io.github.toberocat.improvedfactions.api.events.FactionCreateEvent
 import org.jetbrains.exposed.sql.SizedIterable
 import java.util.*
+import java.util.concurrent.CancellationException
 
 /**
  * Created: 04.08.2023
@@ -30,16 +31,19 @@ object FactionHandler {
                 icon = ItemBuilder().title("§e$factionName").material(Material.WOODEN_SWORD)
                     .create(ImprovedFactionsPlugin.instance)
             }
-            createListenersFor(faction)
-
             val ranks = createDefaultRanks(faction.id.value)
 
             faction.defaultRank = ranks.firstOrNull()?.id?.value ?: FactionRankHandler.guestRankId
             faction.join(ownerId, ranks.lastOrNull()?.id?.value ?: FactionRankHandler.guestRankId)
             faction.setAccumulatedPower(faction.maxPower, PowerAccumulationChangeReason.PASSIVE_ENERGY_ACCUMULATION)
+            val event = FactionCreateEvent(faction)
+            Bukkit.getPluginManager().callEvent(event)
+            if (event.isCancelled) {
+                throw CancellationException("Faction creation was cancelled")
+            }
+            createListenersFor(faction)
             return@loggedTransaction faction
         }
-        Bukkit.getPluginManager().callEvent(FactionCreateEvent(faction))
         return faction
     }
 

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/base/BaseModule.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/base/BaseModule.kt
@@ -22,7 +22,6 @@ import io.github.toberocat.improvedfactions.user.factionUser
 import io.github.toberocat.improvedfactions.utils.BStatsCollector
 import io.github.toberocat.improvedfactions.utils.FileUtils
 import io.github.toberocat.improvedfactions.utils.toOfflinePlayer
-import net.kyori.adventure.platform.bukkit.BukkitAudiences
 import org.bukkit.OfflinePlayer
 import org.jetbrains.exposed.sql.Database
 import java.util.logging.Logger
@@ -32,7 +31,6 @@ object BaseModule : Module {
     override val moduleName = MODULE_NAME
     override var isEnabled = false
 
-    lateinit var adventure: BukkitAudiences
     lateinit var config: ImprovedFactionsConfig
     lateinit var database: Database
     lateinit var claimChunkClusters: ClaimClusterDetector
@@ -44,7 +42,6 @@ object BaseModule : Module {
         this.plugin = plugin
         logger = plugin.logger
 
-        adventure = BukkitAudiences.create(plugin)
         claimChunkClusters = ClaimClusterDetector(DatabaseClaimQueryProvider())
         config = ImprovedFactionsConfig.createConfig(plugin)
 
@@ -71,10 +68,6 @@ object BaseModule : Module {
 
     override fun onLoadDatabase(plugin: ImprovedFactionsPlugin) {
         database = DatabaseConnector(plugin).createDatabase()
-    }
-
-    override fun onDisable(plugin: ImprovedFactionsPlugin) {
-        adventure.close()
     }
 
     @PapiPlaceholder("owner", MODULE_NAME, "The owner of the faction")

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/claimparticle/handles/RenderParticlesTask.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/claimparticle/handles/RenderParticlesTask.kt
@@ -56,7 +56,7 @@ class RenderParticlesTask(private val config: ClaimParticleModuleConfig) : Bukki
         )
 
         player.spawnParticle(
-            Particle.REDSTONE,
+            Particle.DUST,
             location,
             config.particleCount,
             config.particleSpread,

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/power/config/PowerManagementConfig.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/power/config/PowerManagementConfig.kt
@@ -34,7 +34,7 @@ data class PowerManagementConfig(
         inactiveAccumulationMultiplier =
             config.getUnsignedDouble("$configPath.accumulation-inactive-multiplier", inactiveAccumulationMultiplier)
         accumulationMultiplier = config.getUnsignedDouble("$configPath.accumulation-multiplier", accumulationMultiplier)
-        inactiveMilliseconds = (config.getEnum<TimeUnit>("$configPath.inactive.unit") ?: TimeUnit.DAYS).toSeconds(
+        inactiveMilliseconds = (config.getEnum<TimeUnit>("$configPath.inactive.unit") ?: TimeUnit.DAYS).toMillis(
             abs(
                 config.getLong("$configPath.inactive.value", 1)
             )

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/power/impl/FactionPowerRaidModuleHandleImpl.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/power/impl/FactionPowerRaidModuleHandleImpl.kt
@@ -19,8 +19,8 @@ const val TICKS_TO_MS = 50
 
 class FactionPowerRaidModuleHandleImpl(private val config: PowerManagementConfig) : FactionPowerRaidModuleHandle {
 
-    private var accumulateTaskId: Int = 0
-    private var claimKeepCostTaskId: Int = 1
+    private var accumulateTaskId: Int? = null
+    private var claimKeepCostTaskId: Int? = null
     private var lastAccumulationMs = System.currentTimeMillis()
     private var lastClaimKeepCostMs = System.currentTimeMillis()
 
@@ -73,8 +73,8 @@ class FactionPowerRaidModuleHandleImpl(private val config: PowerManagementConfig
     fun nextClaimKeepCostCycleTime() = lastClaimKeepCostMs + config.accumulationTickDelay * TICKS_TO_MS
 
     override fun reloadConfig(plugin: ImprovedFactionsPlugin) {
-        Bukkit.getScheduler().cancelTask(accumulateTaskId)
-        Bukkit.getScheduler().cancelTask(claimKeepCostTaskId)
+        accumulateTaskId?.let(Bukkit.getScheduler()::cancelTask)
+        claimKeepCostTaskId?.let(Bukkit.getScheduler()::cancelTask)
 
         accumulateTaskId = Bukkit.getScheduler()
             .runTaskTimer(plugin, ::accumulateAll, config.accumulationTickDelay, config.accumulationTickDelay).taskId
@@ -115,9 +115,11 @@ class FactionPowerRaidModuleHandleImpl(private val config: PowerManagementConfig
         getPowerAccumulated(getActivePowerAccumulation(faction), getInactivePowerAccumulation(faction))
 
     override fun getActivePowerAccumulation(faction: Faction) =
-        (1 + faction.countActiveMembers(config.accumulationTickDelay) / faction.members().count().toDouble()).pow(
-            config.activeAccumulationExponent
-        ) * config.accumulationMultiplier
+        faction.members().count().takeIf { it > 0 }?.let { memberCount ->
+            (1 + faction.countActiveMembers(config.accumulationTickDelay) / memberCount.toDouble()).pow(
+                config.activeAccumulationExponent
+            ) * config.accumulationMultiplier
+        } ?: 0.0
 
 
     override fun getClaimMaintenanceCost(faction: Faction) = getClaimMaintenanceCost(faction.claims().count())

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/relations/database/FactionAllyInvites.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/relations/database/FactionAllyInvites.kt
@@ -19,6 +19,7 @@ object FactionAllyInvites : IntIdTable("faction_ally_invites") {
     val expirationDate = datetime("expiration_date")
 
     fun scheduleInviteExpirations() = FactionAllyInvite.all().forEach {
+        val inviteId = it.id.value
         val ticksTillExpired = (it.expirationDate.toInstant(TimeZone.UTC) - Clock.System.now()).inWholeSeconds * 20
         if (ticksTillExpired <= 0) {
             it.delete()
@@ -26,7 +27,9 @@ object FactionAllyInvites : IntIdTable("faction_ally_invites") {
         }
 
         Bukkit.getScheduler().runTaskLater(
-            ImprovedFactionsPlugin.instance, Runnable { loggedTransaction { it.delete() } }, ticksTillExpired
+            ImprovedFactionsPlugin.instance,
+            Runnable { loggedTransaction { FactionAllyInvite.findById(inviteId)?.delete() } },
+            ticksTillExpired
         )
     }
 }

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/wilderness/commands/WildernessCommand.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/wilderness/commands/WildernessCommand.kt
@@ -56,10 +56,10 @@ abstract class WildernessCommand : WildernessCommandContext() {
     }
 
     private fun teleport(location: Location, player: Player) {
-        if (WildernessModule.config.gainResistance && !player.hasPotionEffect(PotionEffectType.DAMAGE_RESISTANCE)) {
+        if (WildernessModule.config.gainResistance && !player.hasPotionEffect(PotionEffectType.RESISTANCE)) {
             player.addPotionEffect(
                 PotionEffect(
-                    PotionEffectType.DAMAGE_RESISTANCE,
+                    PotionEffectType.RESISTANCE,
                     WildernessModule.config.resistanceDuration * 20,
                     WildernessModule.config.resistanceAmplifier,
                     false,

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/wilderness/config/WildernessModuleConfig.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/wilderness/config/WildernessModuleConfig.kt
@@ -86,7 +86,7 @@ class WildernessModuleConfig(
         if (preventSpawnOverLiquids && location.block.isLiquid) {
             return false
         }
-        if (blacklistedBiomes.contains(location.block.biome.name)) {
+        if (blacklistedBiomes.contains(location.block.biome.key.key.uppercase())) {
             return false
         }
         if (!pluginConfig.allowedWorlds.contains(location.world?.name)) {

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/translation/ExternalResourceBundleLoader.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/translation/ExternalResourceBundleLoader.kt
@@ -10,6 +10,8 @@ import java.util.*
  * @author Tobias Madlberger (Tobias)
  */
 class ExternalResourceBundleLoader(private val bundlePath: String) : ResourceBundle.Control() {
+    private val fallbackLocale = Locale.US
+
     @Throws(IOException::class)
     override fun newBundle(
         baseName: String,
@@ -26,5 +28,10 @@ class ExternalResourceBundleLoader(private val bundlePath: String) : ResourceBun
         return super.newBundle(baseName, locale, format, loader, reload)
     }
 
-    override fun getFallbackLocale(baseName: String?, locale: Locale?): Locale = Locale.ENGLISH
+    override fun getFallbackLocale(baseName: String?, locale: Locale?): Locale? {
+        if (locale == null || locale == fallbackLocale) {
+            return null
+        }
+        return fallbackLocale
+    }
 }

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/utils/Extensions.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/utils/Extensions.kt
@@ -5,7 +5,6 @@ import io.github.toberocat.improvedfactions.annotations.command.CommandMeta
 import io.github.toberocat.improvedfactions.annotations.command.GeneratedCommandMeta
 import io.github.toberocat.improvedfactions.commands.CommandProcessor
 import io.github.toberocat.improvedfactions.database.DatabaseManager.loggedTransaction
-import io.github.toberocat.improvedfactions.modules.base.BaseModule
 import io.github.toberocat.improvedfactions.utils.offline.KnownOfflinePlayer
 import io.github.toberocat.improvedfactions.utils.offline.KnownOfflinePlayers
 import io.github.toberocat.toberocore.command.SubCommand
@@ -22,7 +21,7 @@ import kotlin.reflect.full.isSubclassOf
 
 inline fun <T, R> T.compute(computeBlock: (T) -> R) = computeBlock(this)
 
-fun Player.toAudience(): Audience = BaseModule.adventure.player(this)
+fun Player.toAudience(): Audience = this
 
 fun UUID.toOfflinePlayer(): OfflinePlayer = Bukkit.getOfflinePlayer(this)
 

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/utils/particles/TeleportParticles.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/utils/particles/TeleportParticles.kt
@@ -25,7 +25,7 @@ class TeleportParticles(
             val x = center.x + helixRadius * cos(angle)
             val z = center.z + helixRadius * sin(angle)
             val location = Location(center.world, x, center.y + height, z)
-            location.world!!.spawnParticle(Particle.TOTEM, location, 1, 0.0, 0.0, 0.0, 0.0)
+            location.world!!.spawnParticle(Particle.TOTEM_OF_UNDYING, location, 1, 0.0, 0.0, 0.0, 0.0)
         }
     }
 }

--- a/improved-factions/src/main/resources/plugin.yml
+++ b/improved-factions/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: ImprovedFactions
 version: '${version}'
 main: io.github.toberocat.improvedfactions.ImprovedFactionsPlugin
-api-version: '1.18'
+api-version: '26.2'
 softdepend: [ PlaceholderAPI, dynmap, GuiEngine ]
 author: Tobero
 commands:

--- a/improved-factions/src/main/resources/plugin.yml
+++ b/improved-factions/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: ImprovedFactions
 version: '${version}'
 main: io.github.toberocat.improvedfactions.ImprovedFactionsPlugin
-api-version: '26.2'
+api-version: '1.21.11'
 softdepend: [ PlaceholderAPI, dynmap, GuiEngine ]
 author: Tobero
 commands:

--- a/improved-factions/src/main/resources/plugin.yml
+++ b/improved-factions/src/main/resources/plugin.yml
@@ -1,180 +1,179 @@
 name: ImprovedFactions
 version: '${version}'
 main: io.github.toberocat.improvedfactions.ImprovedFactionsPlugin
-api-version: '1.21.11'
+api-version: '26.1.2'
 softdepend: [ PlaceholderAPI, dynmap, GuiEngine ]
 author: Tobero
 commands:
   factions:
     aliases: [ "f", "fac", "faction" ]
 
-permissions: 
-  factions.updatechecker: 
+permissions:
+  factions.updatechecker:
     default: op
-  factions.commands.admin.bypass: 
+  factions.commands.chat:
+    default: true
+  factions.commands.admin.spy:
+    default: true
+  factions.commands.wilderness:
+    default: true
+  factions.commands.home:
+    default: true
+  factions.commands.sethome:
+    default: true
+  factions.commands.admin.power.set:
+    default: true
+  factions.commands.admin.power.add:
+    default: true
+  factions.commands.siege:
+    default: true
+  factions.commands.power:
+    default: true
+  factions.commands.allyaccept:
+    default: true
+  factions.commands.ally:
+    default: true
+  factions.commands.war:
+    default: true
+  factions.commands.enemies:
+    default: true
+  factions.commands.allies:
+    default: true
+  factions.commands.admin.zone.unclaim:
     default: op
-  factions.commands.admin.disband: 
+  factions.commands.admin.zone.claim:
     default: op
-  factions.commands.admin.claim: 
+  factions.commands.admin.bypass:
     default: op
-  factions.commands.admin.playerinfo: 
+  factions.commands.admin.claim:
     default: op
-  factions.commands.admin.join: 
+  factions.commands.admin.playerinfo:
     default: op
-  factions.commands.admin.leave: 
+  factions.commands.admin.leave:
     default: op
-  factions.commands.admin.unclaim: 
+  factions.commands.admin.join:
     default: op
-  factions.commands.admin.reload: 
+  factions.commands.admin.unclaim:
     default: op
-  factions.commands.admin.zone.claim: 
+  factions.commands.admin.disband:
     default: op
-  factions.commands.admin.zone.unclaim: 
+  factions.commands.admin.reload:
     default: op
-  factions.commands.claim: 
+  factions.commands.rank.assign:
     default: true
-  factions.commands.map: 
+  factions.commands.rank.delete:
     default: true
-  factions.commands.unclaim: 
+  factions.commands.rank.edit:
     default: true
-  factions.commands.help: 
+  factions.commands.rank.set:
     default: true
-  factions.commands.info: 
+  factions.commands.rank.default:
     default: true
-  factions.commands.list: 
+  factions.commands.rank:
     default: true
-  factions.commands.version: 
+  factions.commands.rank.create:
     default: true
-  factions.commands.inviteaccept: 
+  factions.commands.invitediscard:
     default: true
-  factions.commands.invite: 
+  factions.commands.invite:
     default: true
-  factions.commands.invitediscard: 
+  factions.commands.invites:
     default: true
-  factions.commands.invites: 
+  factions.commands.inviteaccept:
     default: true
-  factions.commands.create: 
+  factions.commands.claim:
     default: true
-  factions.commands.delete: 
+  factions.commands.unclaim:
     default: true
-  factions.commands.icon: 
+  factions.commands.map:
     default: true
-  factions.commands.joinmode: 
+  factions.commands.delete:
     default: true
-  factions.commands.rename: 
+  factions.commands.icon:
     default: true
-  factions.commands.ban: 
+  factions.commands.rename:
     default: true
-  factions.commands.join: 
+  factions.commands.joinmode:
     default: true
-  factions.commands.kick: 
+  factions.commands.create:
     default: true
-  factions.commands.leave: 
+  factions.commands.join:
     default: true
-  factions.commands.members: 
+  factions.commands.kick:
     default: true
-  factions.commands.transferowner: 
+  factions.commands.leave:
     default: true
-  factions.commands.unban: 
+  factions.commands.unban:
     default: true
-  factions.commands.rank.assign: 
+  factions.commands.transferowner:
     default: true
-  factions.commands.rank.create: 
+  factions.commands.members:
     default: true
-  factions.commands.rank.default: 
+  factions.commands.ban:
     default: true
-  factions.commands.rank.delete: 
+  factions.commands.info:
     default: true
-  factions.commands.rank.edit: 
+  factions.commands.help:
     default: true
-  factions.commands.rank: 
+  factions.commands.version:
     default: true
-  factions.commands.rank.set: 
+  factions.commands.list:
     default: true
-  factions.commands.chat: 
-    default: true
-  factions.commands.admin.spy: 
-    default: true
-  factions.commands.sethome: 
-    default: true
-  factions.commands.home: 
-    default: true
-  factions.commands.admin.power.add: 
-    default: true
-  factions.commands.power: 
-    default: true
-  factions.commands.admin.power.set: 
-    default: true
-  factions.commands.siege: 
-    default: true
-  factions.commands.allies: 
-    default: true
-  factions.commands.allyaccept: 
-    default: true
-  factions.commands.ally: 
-    default: true
-  factions.commands.enemies: 
-    default: true
-  factions.commands.war: 
-    default: true
-  factions.commands.wilderness: 
-    default: true
-  factions.*: 
+  factions.*:
     default: op
-    children: 
+    children:
       factions.updatechecker: true
+      factions.commands.chat: true
+      factions.commands.admin.spy: true
+      factions.commands.wilderness: true
+      factions.commands.home: true
+      factions.commands.sethome: true
+      factions.commands.admin.power.set: true
+      factions.commands.admin.power.add: true
+      factions.commands.siege: true
+      factions.commands.power: true
+      factions.commands.allyaccept: true
+      factions.commands.ally: true
+      factions.commands.war: true
+      factions.commands.enemies: true
+      factions.commands.allies: true
+      factions.commands.admin.zone.unclaim: true
+      factions.commands.admin.zone.claim: true
       factions.commands.admin.bypass: true
-      factions.commands.admin.disband: true
       factions.commands.admin.claim: true
       factions.commands.admin.playerinfo: true
-      factions.commands.admin.join: true
       factions.commands.admin.leave: true
+      factions.commands.admin.join: true
       factions.commands.admin.unclaim: true
+      factions.commands.admin.disband: true
       factions.commands.admin.reload: true
-      factions.commands.admin.zone.claim: true
-      factions.commands.admin.zone.unclaim: true
-      factions.commands.claim: true
-      factions.commands.map: true
-      factions.commands.unclaim: true
-      factions.commands.help: true
-      factions.commands.info: true
-      factions.commands.list: true
-      factions.commands.version: true
-      factions.commands.inviteaccept: true
-      factions.commands.invite: true
+      factions.commands.rank.assign: true
+      factions.commands.rank.delete: true
+      factions.commands.rank.edit: true
+      factions.commands.rank.set: true
+      factions.commands.rank.default: true
+      factions.commands.rank: true
+      factions.commands.rank.create: true
       factions.commands.invitediscard: true
+      factions.commands.invite: true
       factions.commands.invites: true
-      factions.commands.create: true
+      factions.commands.inviteaccept: true
+      factions.commands.claim: true
+      factions.commands.unclaim: true
+      factions.commands.map: true
       factions.commands.delete: true
       factions.commands.icon: true
-      factions.commands.joinmode: true
       factions.commands.rename: true
-      factions.commands.ban: true
+      factions.commands.joinmode: true
+      factions.commands.create: true
       factions.commands.join: true
       factions.commands.kick: true
       factions.commands.leave: true
-      factions.commands.members: true
-      factions.commands.transferowner: true
       factions.commands.unban: true
-      factions.commands.rank.assign: true
-      factions.commands.rank.create: true
-      factions.commands.rank.default: true
-      factions.commands.rank.delete: true
-      factions.commands.rank.edit: true
-      factions.commands.rank: true
-      factions.commands.rank.set: true
-      factions.commands.chat: true
-      factions.commands.admin.spy: true
-      factions.commands.sethome: true
-      factions.commands.home: true
-      factions.commands.admin.power.add: true
-      factions.commands.power: true
-      factions.commands.admin.power.set: true
-      factions.commands.siege: true
-      factions.commands.allies: true
-      factions.commands.allyaccept: true
-      factions.commands.ally: true
-      factions.commands.enemies: true
-      factions.commands.war: true
-      factions.commands.wilderness: true
-
+      factions.commands.transferowner: true
+      factions.commands.members: true
+      factions.commands.ban: true
+      factions.commands.info: true
+      factions.commands.help: true
+      factions.commands.version: true
+      factions.commands.list: true

--- a/improved-factions/src/test/kotlin/io/github/toberocat/improvedfactions/ImprovedFactionsTest.kt
+++ b/improved-factions/src/test/kotlin/io/github/toberocat/improvedfactions/ImprovedFactionsTest.kt
@@ -4,6 +4,7 @@ import io.github.toberocat.improvedfactions.factions.Faction
 import io.github.toberocat.improvedfactions.factions.FactionHandler
 import io.github.toberocat.improvedfactions.modules.base.BaseModule
 import org.bukkit.Material
+import org.bukkit.inventory.ItemType
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -20,6 +21,7 @@ open class ImprovedFactionsTest {
     open fun setUp() {
         System.setProperty("bstats.relocatecheck", "false")
         server = MockBukkit.mock()
+        server.getRegistry(ItemType::class.java)!!.stream().count()
         plugin = MockBukkit.load(ImprovedFactionsPlugin::class.java)
     }
 

--- a/improved-factions/version.properties
+++ b/improved-factions/version.properties
@@ -1,3 +1,3 @@
-#Sat Jan 03 11:29:27 CET 2026
-buildIncrement=43
+#Sat Aug 08 14:28:45 CEST 2026
+buildIncrement=165
 versionName=2.3.1


### PR DESCRIPTION
## Summary

This supersedes the older Paper update attempt in #360 and targets `dev` directly.

- Move the plugin from Spigot to Paper API `26.1.2.build.72-stable`
- Use the matching MockBukkit artifact `mockbukkit-v26.1.2:4.115.0`
- Update the build and CI toolchain to Java 25
- Update compatible dependencies, including SQLite, H2, Adventure, Gson, SnakeYAML, bStats, PlaceholderAPI, Shadow, Dokka, KSP, and Gradle
- Keep Paper's Adventure 4.26.1 line for binary compatibility
- Update code generation and localization to the `messages_en_US.properties` resource without legacy fallback files
- Retain the relevant API/runtime fixes from #360
- Remove the old dependency-resolution workaround and Spigot API references

## Verification

- Full Gradle test suite on Java 25
- 61 tests, 0 failures, 0 errors, 0 skipped
- Exact resolved test dependencies verified: Paper `26.1.2.build.72-stable` and MockBukkit `4.115.0`
