### PR TITLE
fix: render console messages and expose member placeholders

### DIFF
--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/integrations/papi/PlaceholderIntegration.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/integrations/papi/PlaceholderIntegration.kt
@@ -27,6 +27,10 @@ object PlaceholderIntegration {
             "name" -> faction?.name
             "rank" -> user.rankName
             "join_mode" -> faction?.joinType
+            "members_total" -> faction?.let { cache.factionMembers(it.id).size.toString() }
+            "members_online" -> faction?.let {
+                cache.factionMembers(it.id).count { memberId -> Bukkit.getPlayer(memberId) != null }.toString()
+            }
             "power" -> faction?.accumulatedPower?.toString()
             "max_power" -> faction?.maxPower?.toString()
             "next_power_gain" -> faction?.let(::nextPowerGain)?.let { String.format("%.2f", it) }

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/base/BaseModule.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/modules/base/BaseModule.kt
@@ -85,8 +85,10 @@ object BaseModule : Module {
     @PapiPlaceholder("name", MODULE_NAME, "The name of the faction")
     @PapiPlaceholder("rank", MODULE_NAME, "The rank of the player in the faction")
     @PapiPlaceholder("join_mode", MODULE_NAME, "The join mode of the faction")
+    @PapiPlaceholder("members_total", MODULE_NAME, "The total number of members in the faction")
+    @PapiPlaceholder("members_online", MODULE_NAME, "The number of online members in the faction")
     override fun onPlaceholder(placeholders: HashMap<String, (player: OfflinePlayer) -> String?>) {
-        listOf("owner", "name", "rank", "join_mode").forEach { key ->
+        listOf("owner", "name", "rank", "join_mode", "members_total", "members_online").forEach { key ->
             placeholders[key] = { PlaceholderIntegration.parsePlaceholder(it, key) }
         }
     }

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/translation/Translation.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/translation/Translation.kt
@@ -25,7 +25,7 @@ fun CommandSender.resolveLocalization(key: String, placeholders: Map<String, Str
 fun CommandSender.sendLocalized(key: String, placeholders: Map<String, String> = emptyMap()) {
     when (this) {
         is Player -> sendLocalized(key, placeholders)
-        else -> sendMessage(Locale.ENGLISH.localizeUnformatted(key, placeholders))
+        else -> sendMessage(Locale.ENGLISH.localize(key, placeholders))
     }
 }
 

--- a/improved-factions/src/test/kotlin/io/github/toberocat/improvedfactions/integration/PlaceholderIntegrationTest.kt
+++ b/improved-factions/src/test/kotlin/io/github/toberocat/improvedfactions/integration/PlaceholderIntegrationTest.kt
@@ -1,0 +1,27 @@
+package io.github.toberocat.improvedfactions.integration
+
+import io.github.toberocat.improvedfactions.ImprovedFactionsTest
+import io.github.toberocat.improvedfactions.integrations.papi.PlaceholderIntegration
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class PlaceholderIntegrationTest : ImprovedFactionsTest() {
+    @Test
+    fun `members total placeholder counts all faction members`() {
+        val owner = createTestPlayer("Owner")
+        val member = createTestPlayer("Member")
+        testFaction(owner.uniqueId, member.uniqueId)
+
+        assertEquals("2", PlaceholderIntegration.parsePlaceholder(owner, "members_total"))
+    }
+
+    @Test
+    fun `members online placeholder only counts online faction members`() {
+        val owner = createTestPlayer("Owner")
+        val member = createTestPlayer("Member")
+        testFaction(owner.uniqueId, member.uniqueId)
+        member.disconnect()
+
+        assertEquals("1", PlaceholderIntegration.parsePlaceholder(owner, "members_online"))
+    }
+}

--- a/improved-factions/src/test/kotlin/io/github/toberocat/improvedfactions/integration/TranslationIntegrationTest.kt
+++ b/improved-factions/src/test/kotlin/io/github/toberocat/improvedfactions/integration/TranslationIntegrationTest.kt
@@ -1,0 +1,23 @@
+package io.github.toberocat.improvedfactions.integration
+
+import io.github.toberocat.improvedfactions.ImprovedFactionsTest
+import io.github.toberocat.improvedfactions.translation.sendLocalized
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class TranslationIntegrationTest : ImprovedFactionsTest() {
+    @Test
+    fun `console localization renders MiniMessage instead of printing tags`() {
+        server.consoleSender.sendLocalized("base.commands.unknown-command")
+
+        val component = assertNotNull(server.consoleSender.nextComponentMessage())
+        val plainText = PlainTextComponentSerializer.plainText().serialize(component)
+
+        assertTrue(plainText.contains("Unknown command"))
+        assertFalse(plainText.contains("<red>"))
+        assertFalse(plainText.contains("</red>"))
+    }
+}


### PR DESCRIPTION
## Summary
- render translated console output instead of emitting raw MiniMessage tags
- add faction member total and online placeholders
- add regression coverage for both behaviors