### PR TITLE
fix: drain storage writes during plugin shutdown

### DIFF
--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/database/storage/StorageDispatcher.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/database/storage/StorageDispatcher.kt
@@ -35,10 +35,30 @@ class StorageDispatcher private constructor(parallelism: Int) : AutoCloseable {
     }
 
     override fun close() {
-        if (!closed.compareAndSet(false, true)) return
+        close(DEFAULT_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+    }
+
+    /**
+     * Stops accepting new work and lets work already accepted by the dispatcher finish.
+     *
+     * @return true when all work finished before [timeout]; false when the forced-cancellation
+     * fallback was required.
+     */
+    fun close(timeout: Long, unit: TimeUnit): Boolean {
+        require(timeout >= 0) { "Shutdown timeout must not be negative" }
+        if (!closed.compareAndSet(false, true)) return executor.isTerminated
+
+        executor.shutdown()
+        try {
+            if (executor.awaitTermination(timeout, unit)) return true
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+        }
+
         executor.shutdownNow().forEach { queued ->
             (queued as? StorageWork<*>)?.cancel()
         }
+        return false
     }
 
     private class StorageWork<T>(
@@ -63,6 +83,7 @@ class StorageDispatcher private constructor(parallelism: Int) : AutoCloseable {
     }
 
     companion object {
+        private const val DEFAULT_SHUTDOWN_TIMEOUT_SECONDS = 10L
         private val threadCounter = AtomicInteger()
 
         fun create(databaseType: DatabaseType, mysqlParallelism: Int): StorageDispatcher {

--- a/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/database/storage/StorageManager.kt
+++ b/improved-factions/src/main/kotlin/io/github/toberocat/improvedfactions/database/storage/StorageManager.kt
@@ -5,6 +5,7 @@ import io.github.toberocat.improvedfactions.database.DatabaseSettings
 import io.github.toberocat.improvedfactions.modules.power.config.PowerManagementConfig
 import java.util.UUID
 import java.util.concurrent.CompletionStage
+import java.util.concurrent.TimeUnit
 import java.sql.Connection
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -130,10 +131,17 @@ object StorageManager {
         jdbcRepository = null
         mainThreadContinuation = null
         snapshotListeners.clear()
-        dispatcher?.close()
+        val currentDispatcher = dispatcher
         dispatcher = null
+        if (currentDispatcher != null && !currentDispatcher.close(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            logger?.warning(
+                "Timed out waiting for storage writes to finish during shutdown; remaining work was cancelled"
+            )
+        }
         dataSource?.close()
         dataSource = null
         cache.clear()
     }
+
+    private const val SHUTDOWN_TIMEOUT_SECONDS = 10L
 }

--- a/improved-factions/src/test/kotlin/io/github/toberocat/improvedfactions/unit/database/StorageDispatcherTest.kt
+++ b/improved-factions/src/test/kotlin/io/github/toberocat/improvedfactions/unit/database/StorageDispatcherTest.kt
@@ -5,9 +5,9 @@ import io.github.toberocat.improvedfactions.database.storage.StorageDispatcher
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertFailsWith
-import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 class StorageDispatcherTest {
@@ -65,22 +65,48 @@ class StorageDispatcherTest {
     }
 
     @Test
-    fun `shutdown rejects new work and completes queued work exceptionally`() {
+    fun `graceful shutdown completes an already queued write before returning`() {
         val dispatcher = StorageDispatcher.create(DatabaseType.SQLITE, mysqlParallelism = 4)
         val started = CountDownLatch(1)
         val release = CountDownLatch(1)
+        val persisted = AtomicBoolean()
         val running = dispatcher.submit {
             started.countDown()
             release.await(2, TimeUnit.SECONDS)
         }
         assertTrue(started.await(2, TimeUnit.SECONDS))
+        val queuedWrite = dispatcher.submit { persisted.set(true) }
+
+        Thread {
+            Thread.sleep(50)
+            release.countDown()
+        }.start()
+
+        assertTrue(dispatcher.close(2, TimeUnit.SECONDS))
+
+        assertTrue(persisted.get())
+        assertTrue(queuedWrite.toCompletableFuture().isDone)
+        assertTrue(running.toCompletableFuture().isDone)
+        assertFailsWith<Exception> { dispatcher.submit { Unit } }
+    }
+
+    @Test
+    fun `graceful shutdown falls back to cancellation after its timeout`() {
+        val dispatcher = StorageDispatcher.create(DatabaseType.SQLITE, mysqlParallelism = 4)
+        val started = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val running = dispatcher.submit {
+            started.countDown()
+            release.await()
+        }
+        assertTrue(started.await(2, TimeUnit.SECONDS))
         val queued = dispatcher.submit { "never" }
 
-        dispatcher.close()
-        release.countDown()
+        assertTrue(!dispatcher.close(10, TimeUnit.MILLISECONDS))
 
         assertTrue(queued.toCompletableFuture().isCompletedExceptionally)
         assertFailsWith<Exception> { dispatcher.submit { Unit } }
-        assertNotEquals(false, running.toCompletableFuture().isDone)
+        release.countDown()
+        assertTrue(running.toCompletableFuture().isDone)
     }
 }


### PR DESCRIPTION
## Summary
- stop accepting new storage work during plugin disable
- drain already accepted work for up to 10 seconds before closing the datasource
- cancel only remaining queued work after timeout or interruption
- log timeout fallback

## Tests
- regression tests cover graceful completion of queued storage work and timeout fallback
- the full suite passed before the clean cherry-pick; PR CI is required before merge.